### PR TITLE
Close on middle click and move code to plugins/xbutton.py

### DIFF
--- a/porcupine/plugins/xbutton.py
+++ b/porcupine/plugins/xbutton.py
@@ -1,0 +1,40 @@
+"""Allow tabs to be closed with "X" button or middle-click."""
+
+import tkinter
+
+from porcupine import get_tab_manager, images, tabs
+
+
+def close_clicked_tab(event: 'tkinter.Event[tabs.TabManager]') -> None:
+    tab = event.widget.tabs()[event.widget.index(f'@{event.x},{event.y}')]
+    if tab.can_be_closed():
+        event.widget.close_tab(tab)
+
+
+def on_click(event: 'tkinter.Event[tabs.TabManager]') -> None:
+    if event.widget.identify(event.x, event.y) == 'label':
+        # find the right edge of the top label (including close button)
+        right = event.x
+        while event.widget.identify(right, event.y) == 'label':
+            right += 1
+
+        # hopefully the image is on the right edge of the label and
+        # there's no padding :O
+        if event.x >= right - images.get('closebutton').width():
+            close_clicked_tab(event)
+
+
+# Close tab on middle-click (press down the wheel of the mouse)
+def on_middle_click(event: 'tkinter.Event[tabs.TabManager]') -> None:
+    if event.widget.identify(event.x, event.y) == 'label':
+        close_clicked_tab(event)
+
+
+def setup() -> None:
+    tabmanager = get_tab_manager()
+    tabmanager.add_tab_callback(lambda tab: get_tab_manager().tab(
+        tab, image=images.get('closebutton'), compound='right'
+    ))
+    tabmanager.bind('<Button-1>', on_click, add=True)
+    # TODO: <Button-2> is right-click on Mac, is that good for this?
+    tabmanager.bind('<Button-2>', on_middle_click, add=True)

--- a/porcupine/plugins/xbutton.py
+++ b/porcupine/plugins/xbutton.py
@@ -18,8 +18,7 @@ def on_click(event: 'tkinter.Event[tabs.TabManager]') -> None:
         while event.widget.identify(right, event.y) == 'label':
             right += 1
 
-        # hopefully the image is on the right edge of the label and
-        # there's no padding :O
+        # hopefully the image is on the right edge of the label and there's no padding :O
         if event.x >= right - images.get('closebutton').width():
             close_clicked_tab(event)
 

--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -89,6 +89,7 @@ class TabManager(ttk.Notebook):
 
         self.bind('<<NotebookTabChanged>>', self._focus_selected_tab, add=True)
         self.bind('<Button-1>', self._on_click, add=True)
+        self.bind('<Button-2>', self._on_middle_click, add=True)
         utils.bind_mouse_wheel(self, self._on_wheel, add=True)
 
         # the string is call stack for adding callback
@@ -104,16 +105,23 @@ class TabManager(ttk.Notebook):
             # something else than the top label was clicked
             return
 
-        # find the right edge of the label
+        # find the right edge of the label (including close button)
         right = event.x
         while self.identify(right, event.y) == 'label':
             right += 1
 
         # hopefully the image is on the right edge of the label and
         # there's no padding :O
-        if event.x + images.get('closebutton').width() >= right:
+        if event.x >= right - images.get('closebutton').width():
             # the close button was clicked
-            tab = self.tabs()[self.index('@%d,%d' % (event.x, event.y))]
+            tab = self.tabs()[self.index(f'@{event.x},{event.y}')]
+            if tab.can_be_closed():
+                self.close_tab(tab)
+
+    # Close tab on middle-click (press down the wheel of the mouse)
+    def _on_middle_click(self, event: 'tkinter.Event[tkinter.Misc]') -> None:
+        if self.identify(event.x, event.y) == 'label':
+            tab = self.tabs()[self.index(f'@{event.x},{event.y}')]
             if tab.can_be_closed():
                 self.close_tab(tab)
 

--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -88,8 +88,6 @@ class TabManager(ttk.Notebook):
             self.bindings.append(('<Alt-Key-%d>' % number, callback))
 
         self.bind('<<NotebookTabChanged>>', self._focus_selected_tab, add=True)
-        self.bind('<Button-1>', self._on_click, add=True)
-        self.bind('<Button-2>', self._on_middle_click, add=True)
         utils.bind_mouse_wheel(self, self._on_wheel, add=True)
 
         # the string is call stack for adding callback
@@ -99,31 +97,6 @@ class TabManager(ttk.Notebook):
         tab = self.select()
         if tab is not None:
             tab.on_focus()
-
-    def _on_click(self, event: 'tkinter.Event[tkinter.Misc]') -> None:
-        if self.identify(event.x, event.y) != 'label':
-            # something else than the top label was clicked
-            return
-
-        # find the right edge of the label (including close button)
-        right = event.x
-        while self.identify(right, event.y) == 'label':
-            right += 1
-
-        # hopefully the image is on the right edge of the label and
-        # there's no padding :O
-        if event.x >= right - images.get('closebutton').width():
-            # the close button was clicked
-            tab = self.tabs()[self.index(f'@{event.x},{event.y}')]
-            if tab.can_be_closed():
-                self.close_tab(tab)
-
-    # Close tab on middle-click (press down the wheel of the mouse)
-    def _on_middle_click(self, event: 'tkinter.Event[tkinter.Misc]') -> None:
-        if self.identify(event.x, event.y) == 'label':
-            tab = self.tabs()[self.index(f'@{event.x},{event.y}')]
-            if tab.can_be_closed():
-                self.close_tab(tab)
 
     def _on_wheel(self, direction: str) -> None:
         self.select_another_tab({'up': -1, 'down': +1}[direction])
@@ -217,7 +190,7 @@ class TabManager(ttk.Notebook):
                 tab.destroy()
                 return existing_tab
 
-        self.add(tab, image=images.get('closebutton'), compound='right')
+        self.add(tab)
         self._update_tab_titles()
         if select:
             self.select(tab)

--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -15,7 +15,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tupl
 from pygments.lexer import LexerMeta  # type: ignore[import]
 from pygments.lexers import TextLexer  # type: ignore[import]
 
-from porcupine import _state, images, settings, textwidget, utils
+from porcupine import _state, settings, textwidget, utils
 
 log = logging.getLogger(__name__)
 _flatten = itertools.chain.from_iterable


### PR DESCRIPTION
Fixes #241 

Also moves the close button stuff into a new plugin, `plugins/xbutton.py`, to simplify the code (`tabs.py` is a long file)