### PR TITLE
Flashing2

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,6 @@ you will likely get a warning similar to this one:
 You should still be able to run the installer by clicking "More info".
 When installed, you will find Porcupine from the start menu.
 
-**Epilepsy warning:**
-Currently the `directory_tree` plugin is unusable and does some weird flashing on Windows.
-You can disable it in the plugin manager (in Settings menu).
-Hopefully this will be fixed in the next release.
-
 ### Development Install
 
 See [below](#developing-porcupine).

--- a/porcupine/__init__.py
+++ b/porcupine/__init__.py
@@ -12,9 +12,9 @@ import platform
 import shutil
 import subprocess
 
-from porcupine.utils import subprocess_kwargs as _subprocess_kwargs
-
 import appdirs  # type: ignore[import]
+
+from porcupine.utils import subprocess_kwargs as _subprocess_kwargs
 
 version_info = (0, 87, 0)        # this is updated with scripts/release.py
 __version__ = '%d.%d.%d' % version_info

--- a/porcupine/__init__.py
+++ b/porcupine/__init__.py
@@ -12,6 +12,8 @@ import platform
 import shutil
 import subprocess
 
+from porcupine.utils import subprocess_kwargs as _subprocess_kwargs
+
 import appdirs  # type: ignore[import]
 
 version_info = (0, 87, 0)        # this is updated with scripts/release.py
@@ -26,7 +28,7 @@ if (_here.parent / '.git').is_dir() and shutil.which('git') is not None:
     # running porcupine from git repo
     try:
         __version__ += '+git.' + subprocess.check_output(
-            ['git', 'log', '--pretty=format:%h', '-n', '1'], cwd=_here
+            ['git', 'log', '--pretty=format:%h', '-n', '1'], cwd=_here, **_subprocess_kwargs
         ).decode('ascii')
     except (OSError, subprocess.CalledProcessError, UnicodeError):   # pragma: no cover
         pass

--- a/porcupine/plugins/directory_tree.py
+++ b/porcupine/plugins/directory_tree.py
@@ -22,9 +22,10 @@ def run_git_status(project_root: pathlib.Path) -> Dict[pathlib.Path, str]:
     extra_args: Dict[str, Any] = {}
     if sys.platform == 'win32':
         # https://stackoverflow.com/a/1813893
-        startupinfo = subprocess.STARTUPINFO()
-        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-        extra_args = {'startupinfo': startupinfo}
+        # TODO: simplify when Python 3.6 support is dropped
+        #extra_args['startupinfo'] = subprocess.STARTUPINFO(dwFlags=subprocess.STARTF_USESHOWWINDOW)
+        extra_args['startupinfo'] = subprocess.STARTUPINFO()
+        extra_args['startupinfo'].dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
     try:
         start = time.perf_counter()

--- a/porcupine/plugins/directory_tree.py
+++ b/porcupine/plugins/directory_tree.py
@@ -285,8 +285,7 @@ def setup() -> None:
     container = ttk.Frame(get_paned_window())
     tree = DirectoryTree(container)
     tree.pack(side='left', fill='both', expand=True)
-    # Can't bind to <FocusIn>, causes bug on windows (#327)
-    tree.bind('<Button-1>', tree.refresh_everything, add=True)
+    tree.bind('<FocusIn>', tree.refresh_everything, add=True)
     scrollbar = ttk.Scrollbar(container)
     scrollbar.pack(side='right', fill='y')
 

--- a/porcupine/plugins/directory_tree.py
+++ b/porcupine/plugins/directory_tree.py
@@ -19,14 +19,6 @@ PROJECT_AUTOCLOSE_COUNT = 5
 
 
 def run_git_status(project_root: pathlib.Path) -> Dict[pathlib.Path, str]:
-    extra_args: Dict[str, Any] = {}
-    if sys.platform == 'win32':
-        # https://stackoverflow.com/a/1813893
-        # TODO: simplify when Python 3.6 support is dropped
-        #extra_args['startupinfo'] = subprocess.STARTUPINFO(dwFlags=subprocess.STARTF_USESHOWWINDOW)
-        extra_args['startupinfo'] = subprocess.STARTUPINFO()
-        extra_args['startupinfo'].dwFlags |= subprocess.STARTF_USESHOWWINDOW
-
     try:
         start = time.perf_counter()
         run_result = subprocess.run(
@@ -35,7 +27,7 @@ def run_git_status(project_root: pathlib.Path) -> Dict[pathlib.Path, str]:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,   # for logging error message
             encoding=sys.getfilesystemencoding(),
-            **extra_args)
+            **utils.subprocess_kwargs)
         log.debug(f"git ran in {round((time.perf_counter() - start)*1000)}ms")
 
         if run_result.returncode != 0:

--- a/porcupine/plugins/directory_tree.py
+++ b/porcupine/plugins/directory_tree.py
@@ -19,6 +19,13 @@ PROJECT_AUTOCLOSE_COUNT = 5
 
 
 def run_git_status(project_root: pathlib.Path) -> Dict[pathlib.Path, str]:
+    extra_args: Dict[str, Any] = {}
+    if sys.platform == 'win32':
+        # https://stackoverflow.com/a/1813893
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        extra_args = {'startupinfo': startupinfo}
+
     try:
         start = time.perf_counter()
         run_result = subprocess.run(
@@ -27,7 +34,7 @@ def run_git_status(project_root: pathlib.Path) -> Dict[pathlib.Path, str]:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,   # for logging error message
             encoding=sys.getfilesystemencoding(),
-        )
+            **extra_args)
         log.debug(f"git ran in {round((time.perf_counter() - start)*1000)}ms")
 
         if run_result.returncode != 0:

--- a/porcupine/utils.py
+++ b/porcupine/utils.py
@@ -11,12 +11,13 @@ import pathlib
 import platform
 import re
 import shutil
+import subprocess
 import sys
 import threading
 import tkinter
 import traceback
 from tkinter import ttk
-from typing import TYPE_CHECKING, Any, Callable, Deque, Iterator, Optional, TextIO, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Deque, Dict, Iterator, Optional, TextIO, Type, TypeVar, Union, cast
 
 import dacite
 
@@ -127,6 +128,17 @@ if platform.system() == 'Windows':
 else:
     from shlex import quote
     quote = quote       # silence pyflakes warning
+
+
+# Using these with subprocess prevents opening unnecessary cmd windows
+# TODO: document this
+subprocess_kwargs: Dict[str, Any] = {}
+if sys.platform == 'win32':
+    # https://stackoverflow.com/a/1813893
+    # TODO: simplify when Python 3.6 support is dropped
+    #subprocess_kwargs['startupinfo'] = subprocess.STARTUPINFO(dwFlags=subprocess.STARTF_USESHOWWINDOW)
+    subprocess_kwargs['startupinfo'] = subprocess.STARTUPINFO()
+    subprocess_kwargs['startupinfo'].dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
 
 _PROJECT_ROOT_THINGS = ['.editorconfig', '.git'] + [


### PR DESCRIPTION
fixes #327 

I'm now pretty confident that the flashing happened like this:
1. Directory tree or text widget is focused
2. Refreshing the directory tree contents begins
3. Porcupine runs `git` to figure out how to color things
4. Windows runs `git` in a new `cmd.exe` window
5. Running `git` completes and `cmd.exe` window closes, causing the text widget or directory tree to get focused again
6. Refreshing the directory tree contents begins
7. This continues and `<Arrinao> porcupine resembles a police siren lol`