### PR TITLE
support slashes in filetypes conf

### DIFF
--- a/porcupine/default_filetypes.toml
+++ b/porcupine/default_filetypes.toml
@@ -10,7 +10,7 @@
 #    filename_patterns
 #        List of strings with * used as wildcard, such as "*.py" to match files
 #        named "something.py". You can also specify "foo/*.py" to only match
-#        Python files inside a folder named "foo", but you must use forward
+#        Python files inside a folder named foo, but you must use forward
 #        slashes for this, even on Windows.
 #
 #    shebang_regex

--- a/porcupine/default_filetypes.toml
+++ b/porcupine/default_filetypes.toml
@@ -9,7 +9,9 @@
 #
 #    filename_patterns
 #        List of strings with * used as wildcard, such as "*.py" to match files
-#        named "something.py".
+#        named "something.py". You can also specify "foo/*.py" to only match
+#        Python files inside a folder named "foo", but you must use forward
+#        slashes for this, even on Windows.
 #
 #    shebang_regex
 #        Regular expression checked against the first line of a file when no

--- a/porcupine/plugins/filetypes.py
+++ b/porcupine/plugins/filetypes.py
@@ -106,7 +106,7 @@ def guess_filetype_from_path(filepath: pathlib.Path) -> Optional[FileType]:
             fnmatch.fnmatch(filepath.as_posix(), '*/' + pat)
             for pat in filetype['filename_patterns']
         )
-    }, f"path {filepath}")
+    }, str(filepath))
 
 
 def guess_filetype_from_shebang(content_start: str) -> Optional[FileType]:

--- a/porcupine/plugins/filetypes.py
+++ b/porcupine/plugins/filetypes.py
@@ -70,7 +70,7 @@ def load_filetypes() -> None:
         filetype.setdefault('langserver', None)
 
 
-def set_filedialog_kwargs():
+def set_filedialog_kwargs() -> None:
     filedialog_kwargs['filetypes'] = [("All Files", ["*"])] + [
         (name, [
             # "*.py" doesn't work on windows, but ".py" works and does the same thing

--- a/tests/test_filetypes_plugin.py
+++ b/tests/test_filetypes_plugin.py
@@ -82,11 +82,11 @@ def test_slash_in_filename_patterns(custom_filetypes, caplog, tmp_path):
         )['pygments_lexer'] == 'pygments.lexers.MakoHtmlLexer'
 
     assert len(caplog.records) == 1
-    assert "2 file types match path" in caplog.records[0].message
+    assert "2 file types match" in caplog.records[0].message
     assert str(tmp_path) in caplog.records[0].message
     assert "HTML, Mako template" in caplog.records[0].message
 
-    # Filedialog doesn't support slashes in patterns
+    # filedialog doesn't support slashes in patterns
     for filetype_name, patterns in filedialog_kwargs['filetypes']:
         for pattern in patterns:
             assert "/" not in pattern

--- a/tests/test_filetypes_plugin.py
+++ b/tests/test_filetypes_plugin.py
@@ -5,7 +5,7 @@ from tkinter import filedialog
 
 import pytest
 
-from porcupine import filedialog_kwargs, get_main_window, dirs
+from porcupine import dirs, filedialog_kwargs, get_main_window
 from porcupine.plugins import filetypes
 
 

--- a/tests/test_filetypes_plugin.py
+++ b/tests/test_filetypes_plugin.py
@@ -67,23 +67,23 @@ digraph G {
     assert lexer_class_name.endswith('.TextLexer')
 
 
-def test_slash_in_filename_patterns(custom_filetypes, caplog):
+def test_slash_in_filename_patterns(custom_filetypes, caplog, tmp_path):
     assert filetypes.guess_filetype_from_path(
-        pathlib.Path.home() / "foo" / "bar.html"
+        tmp_path / "foo" / "bar.html"
     )['pygments_lexer'] == 'pygments.lexers.HtmlLexer'
 
     assert filetypes.guess_filetype_from_path(
-        pathlib.Path.home() / "foobar-mako-templates" / "bar.html"
+        tmp_path / "foobar-mako-templates" / "bar.html"
     )['pygments_lexer'] == 'pygments.lexers.HtmlLexer'
 
     with caplog.at_level(logging.WARNING):
         assert filetypes.guess_filetype_from_path(
-            pathlib.Path.home() / "mako-templates" / "bar.html"
+            tmp_path / "mako-templates" / "bar.html"
         )['pygments_lexer'] == 'pygments.lexers.MakoHtmlLexer'
 
     assert len(caplog.records) == 1
     assert "2 file types match path" in caplog.records[0].message
-    assert str(pathlib.Path.home()) in caplog.records[0].message
+    assert str(tmp_path) in caplog.records[0].message
     assert "HTML, Mako template" in caplog.records[0].message
 
     # Filedialog doesn't support slashes in patterns

--- a/tests/test_filetypes_plugin.py
+++ b/tests/test_filetypes_plugin.py
@@ -1,10 +1,33 @@
+import logging
+import pathlib
 import sys
 from tkinter import filedialog
 
 import pytest
 
-from porcupine import filedialog_kwargs, get_main_window
+from porcupine import filedialog_kwargs, get_main_window, dirs
 from porcupine.plugins import filetypes
+
+
+@pytest.fixture
+def custom_filetypes():
+    # We don't overwrite the user's file because porcupine.dirs is monkeypatched
+    assert not dirs.user_config_dir.startswith(str(pathlib.Path.home()))
+    user_filetypes = pathlib.Path(dirs.user_config_dir) / 'filetypes.toml'
+
+    user_filetypes.write_text("""
+['Mako template']
+filename_patterns = ["mako-templates/*.html"]
+pygments_lexer = 'pygments.lexers.MakoHtmlLexer'
+""")
+    filetypes.load_filetypes()
+    filetypes.set_filedialog_kwargs()
+
+    yield
+    user_filetypes.unlink()
+    filetypes.filetypes.clear()
+    filetypes.load_filetypes()
+    filetypes.set_filedialog_kwargs()
 
 
 def test_filedialog_patterns_got_stripped():
@@ -16,7 +39,7 @@ def test_filedialog_patterns_got_stripped():
 @pytest.mark.skipif(
     sys.platform != 'linux',
     reason="don't know how filedialog works on non-Linux")
-def test_actually_running_filedialog():
+def test_actually_running_filedialog(custom_filetypes):
     # Wait and then press Esc. That's done as Tcl code because the Tk widget
     # representing the dialog can't be used with tkinter.
     root = get_main_window().nametowidget('.')
@@ -42,3 +65,28 @@ digraph G {
     filetab.save()
     lexer_class_name = filetypes.get_filetype_for_tab(filetab)['pygments_lexer']
     assert lexer_class_name.endswith('.TextLexer')
+
+
+def test_slash_in_filename_patterns(custom_filetypes, caplog):
+    assert filetypes.guess_filetype_from_path(
+        pathlib.Path.home() / "foo" / "bar.html"
+    )['pygments_lexer'] == 'pygments.lexers.HtmlLexer'
+
+    assert filetypes.guess_filetype_from_path(
+        pathlib.Path.home() / "foobar-mako-templates" / "bar.html"
+    )['pygments_lexer'] == 'pygments.lexers.HtmlLexer'
+
+    with caplog.at_level(logging.WARNING):
+        assert filetypes.guess_filetype_from_path(
+            pathlib.Path.home() / "mako-templates" / "bar.html"
+        )['pygments_lexer'] == 'pygments.lexers.MakoHtmlLexer'
+
+    assert len(caplog.records) == 1
+    assert "2 file types match path" in caplog.records[0].message
+    assert str(pathlib.Path.home()) in caplog.records[0].message
+    assert "HTML, Mako template" in caplog.records[0].message
+
+    # Filedialog doesn't support slashes in patterns
+    for filetype_name, patterns in filedialog_kwargs['filetypes']:
+        for pattern in patterns:
+            assert "/" not in pattern


### PR DESCRIPTION
Fixes #440 

- Allow using forward-slashes in `filename_patterns`
- When multiple matches are found, use the last matching pattern instead of the first one, so that the user's custom config file is used rather than defaults