### PR TITLE
fix log filter problem

### DIFF
--- a/porcupine/_logs.py
+++ b/porcupine/_logs.py
@@ -60,6 +60,14 @@ def _open_log_file() -> TextIO:
     assert False  # makes mypy happy
 
 
+class _FilterThatDoesntHideWarnings(logging.Filter):
+    def __init__(self, verbose_logger_name: str):
+        super().__init__(verbose_logger_name)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.levelno >= logging.WARNING or super().filter(record)
+
+
 # verbose_logger can be:
 #   - empty string (print everything)
 #   - logger name (print only messages from that logger)
@@ -84,7 +92,7 @@ def setup(verbose_logger: Optional[str]) -> None:
             print_handler.setLevel(logging.WARNING)
         else:
             print_handler.setLevel(logging.DEBUG)
-            print_handler.addFilter(logging.Filter(verbose_logger))
+            print_handler.addFilter(_FilterThatDoesntHideWarnings(verbose_logger))
         print_handler.setFormatter(logging.Formatter("%(name)s %(levelname)s: %(message)s"))
         handlers.append(print_handler)
 

--- a/porcupine/_logs.py
+++ b/porcupine/_logs.py
@@ -61,9 +61,6 @@ def _open_log_file() -> TextIO:
 
 
 class _FilterThatDoesntHideWarnings(logging.Filter):
-    def __init__(self, verbose_logger_name: str):
-        super().__init__(verbose_logger_name)
-
     def filter(self, record: logging.LogRecord) -> bool:
         return record.levelno >= logging.WARNING or super().filter(record)
 


### PR DESCRIPTION
Fixes #496 

To test this manually, I ran `python3 -m porcupine --verbose-logger=porcupine.plugins.sort` without tkdnd installed. Before:
```
log file: /home/akuli/.cache/porcupine/log/2021-06-12T01-45-49.txt
porcupine.plugins.sort DEBUG: ran sort.setup() in 0.347 milliseconds
```

After:
```
log file: /home/akuli/.cache/porcupine/log/2021-06-12T01-45-54.txt
porcupine.plugins.drop_to_open ERROR: dragging files to Porcupine won't work because tkdnd isn't installed
porcupine.plugins.sort DEBUG: ran sort.setup() in 2.384 milliseconds
```