### PR TITLE
fix langserver+python_venv error

### DIFF
--- a/porcupine/plugins/langserver.py
+++ b/porcupine/plugins/langserver.py
@@ -31,6 +31,7 @@ from porcupine import get_tab_manager, tabs, textwidget, utils
 from porcupine.plugins import autocomplete, python_venv, underlines
 
 global_log = logging.getLogger(__name__)
+setup_after = ["python_venv"]
 
 
 # 1024 bytes was way too small, and with this chunk size, it


### PR DESCRIPTION
Fixes #521. Couldn't reproduce outside work, but according to the log, it was in the middle of setting up plugins and it had set up langserver before python_venv. Between them, the restart plugin opened new tabs, which caused the langserver plugin to do things.