### PR TITLE
rename anchors option to anchors_cycle

### DIFF
--- a/porcupine/plugins/anchors.py
+++ b/porcupine/plugins/anchors.py
@@ -63,7 +63,7 @@ class AnchorManager:
             next_anchor_row = min(rows_after_cursor)
             self.tab_textwidget.mark_set("insert", f"{next_anchor_row}.0")
             self.tab_textwidget.see("insert")
-        elif len(anchor_list) >= 2 and settings.get("anchors", bool):
+        elif len(anchor_list) >= 2 and settings.get("anchors_cycle", bool):
             next_anchor_row = min(anchor_rows)
             self.tab_textwidget.mark_set("insert", f"{next_anchor_row}.0")
             self.tab_textwidget.see("insert")
@@ -82,7 +82,7 @@ class AnchorManager:
             previous_anchor_row = max(rows_before_cursor)
             self.tab_textwidget.mark_set("insert", f"{previous_anchor_row}.0")
             self.tab_textwidget.see("insert")
-        elif len(anchor_list) >= 2 and settings.get("anchors", bool):
+        elif len(anchor_list) >= 2 and settings.get("anchors_cycle", bool):
             previous_anchor_row = max(anchor_rows)
             self.tab_textwidget.mark_set("insert", f"{previous_anchor_row}.0")
             self.tab_textwidget.see("insert")
@@ -134,9 +134,9 @@ def on_new_filetab(tab: tabs.FileTab) -> None:
 
 
 def setup() -> None:
-    settings.add_option("anchors", False)
+    settings.add_option("anchors_cycle", False)
     settings.add_checkbutton(
-        "anchors", text="Jumping to previous/next anchor cycles to end/start of file"
+        "anchors_cycle", text="Jumping to previous/next anchor cycles to end/start of file"
     )
     get_tab_manager().add_filetab_callback(on_new_filetab)
 


### PR DESCRIPTION
When you look at `settings.json`, seeing `"anchors": false` looks a bit misleading. If I had to guess without knowing anything else about Porcupine, I would think it disables the whole anchors plugin. I think `"anchors_cycle": false` is much better.

@ThePhilgrim, what do you think?