### PR TITLE
Directory tree: run git statuses in parallel

### DIFF
--- a/porcupine/plugins/directory_tree.py
+++ b/porcupine/plugins/directory_tree.py
@@ -75,7 +75,6 @@ def run_git_status(project_root: Path) -> Dict[Path, str]:
             result[path] = "git_mergeconflict"
         else:
             log.warning(f"unknown git status line: {repr(line)}")
-    print("git status:", project_root, "-->", result)
     return result
 
 
@@ -302,22 +301,17 @@ class DirectoryTree(ttk.Treeview):
         }
 
         def check_if_done() -> None:
-            print("check if done")
             if not all(future.done() for future in git_futures.values()):
-                print("  need other check")
                 self.after(25, check_if_done)
                 return
 
             if set(self.get_children()) == set(project_ids):
-                print("  projects same")
                 self.git_statuses = {path: future.result() for path, future in git_futures.items()}
-                print("  self.git_statuses =", self.git_statuses)
                 for project_id in self.get_children(""):
                     self._update_tags_and_content(get_path(project_id), project_id)
                 self._update_selection_color()
                 log.info(f"refreshing done in {round((time.time()-start_time)*1000)}ms")
             else:
-                print("  projects ch")
                 log.info(
                     "projects added/removed while refreshing, assuming another fresh is coming soon"
                 )

--- a/porcupine/plugins/directory_tree.py
+++ b/porcupine/plugins/directory_tree.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+from concurrent.futures import ThreadPoolExecutor
 import dataclasses
 import logging
 import subprocess
@@ -73,7 +75,12 @@ def run_git_status(project_root: Path) -> Dict[Path, str]:
             result[path] = "git_mergeconflict"
         else:
             log.warning(f"unknown git status line: {repr(line)}")
+    print("git status:", project_root, "-->", result)
     return result
+
+
+# Each git subprocess uses one cpu core
+_git_pool = ThreadPoolExecutor(max_workers=os.cpu_count())
 
 
 # For perf reasons, we want to avoid unnecessary Tcl calls when
@@ -283,35 +290,41 @@ class DirectoryTree(ttk.Treeview):
         settings.set_("directory_tree_projects", [str(get_path(id)) for id in self.get_children()])
 
     def refresh(
-        self, junk: object = None, *, when_done: Callable[[], None] = (lambda: None)
+        self, junk: object = None, *, done_callback: Callable[[], None] = (lambda: None)
     ) -> None:
         log.debug("refreshing begins")
         start_time = time.time()
         self._hide_old_projects()
-        project_ids = self.get_children()
+        project_ids = self.get_children("")
+        git_futures = {
+            path: _git_pool.submit(partial(run_git_status, path))
+            for path in map(get_path, project_ids)
+        }
 
-        def thread_target() -> dict[Path, dict[Path, str]]:
-            return {path: run_git_status(path) for path in map(get_path, project_ids)}
+        def check_if_done() -> None:
+            print("check if done")
+            if not all(future.done() for future in git_futures.values()):
+                print("  need other check")
+                self.after(25, check_if_done)
+                return
 
-        def done_callback(success: bool, result: str | dict[Path, dict[Path, str]]) -> None:
-            log.debug(f"thread done in {round((time.time()-start_time)*1000)}ms")
-            if success and set(self.get_children()) == set(project_ids):
-                assert isinstance(result, dict)
-                self.git_statuses = result
+            if set(self.get_children()) == set(project_ids):
+                print("  projects same")
+                self.git_statuses = {path: future.result() for path, future in git_futures.items()}
+                print("  self.git_statuses =", self.git_statuses)
                 for project_id in self.get_children(""):
                     self._update_tags_and_content(get_path(project_id), project_id)
                 self._update_selection_color()
                 log.info(f"refreshing done in {round((time.time()-start_time)*1000)}ms")
-                when_done()
-            elif success:
+            else:
+                print("  projects ch")
                 log.info(
                     "projects added/removed while refreshing, assuming another fresh is coming soon"
                 )
-                when_done()
-            else:
-                log.error(f"error in git status running thread\n{result}")
 
-        utils.run_in_thread(thread_target, done_callback, check_interval_ms=25)
+            done_callback()
+
+        check_if_done()
 
     def find_project_id(self, item_id: str) -> str:
         # Does not work for dummy items, because they don't use type:num:path scheme
@@ -460,7 +473,7 @@ def on_new_filetab(tree: DirectoryTree, tab: tabs.FileTab) -> None:
     def path_callback(junk: object = None) -> None:
         if tab.path is not None:
             tree.add_project(utils.find_project_root(tab.path))
-            tree.refresh(when_done=partial(tree.select_file, tab.path))
+            tree.refresh(done_callback=partial(tree.select_file, tab.path))
 
     path_callback()
 

--- a/porcupine/plugins/directory_tree.py
+++ b/porcupine/plugins/directory_tree.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-import os
-from concurrent.futures import ThreadPoolExecutor
 import dataclasses
 import logging
+import os
 import subprocess
 import sys
 import time
 import tkinter
+from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from pathlib import Path
 from tkinter import ttk

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,13 +10,12 @@ import subprocess
 import sys
 import tempfile
 import tkinter
-import traceback
 
 import appdirs
 import pytest
 
 import porcupine
-from porcupine import dirs, get_main_window, get_tab_manager, plugins, tabs, utils
+from porcupine import dirs, get_main_window, get_tab_manager, plugins, tabs
 from porcupine.__main__ import main
 
 
@@ -99,20 +98,6 @@ def porcusession(monkeypatch_dirs):
         porcupine.get_tab_manager().close_tab(tab)
 
     porcupine.quit()
-
-
-# utils.run_in_thread() can make tests fragile
-@pytest.fixture
-def dont_run_in_thread(monkeypatch):
-    def func(blocking_function, done_callback, check_interval_ms=69, daemon=True):
-        try:
-            result = blocking_function()
-        except Exception:
-            done_callback(False, traceback.format_exc())
-        else:
-            done_callback(True, result)
-
-    monkeypatch.setattr(utils, "run_in_thread", func)
 
 
 @pytest.fixture

--- a/tests/test_pastebin_plugin.py
+++ b/tests/test_pastebin_plugin.py
@@ -3,6 +3,7 @@ import socket
 import threading
 import time
 import tkinter
+import traceback
 import types
 from http.client import RemoteDisconnected
 
@@ -12,6 +13,20 @@ from pygments.lexers import PythonLexer, TextLexer, get_lexer_by_name
 
 import porcupine.plugins.pastebin as pastebin_module
 from porcupine import get_main_window, utils
+
+
+# utils.run_in_thread() can make tests fragile
+@pytest.fixture
+def dont_run_in_thread(monkeypatch):
+    def func(blocking_function, done_callback, check_interval_ms=69, daemon=True):
+        try:
+            result = blocking_function()
+        except Exception:
+            done_callback(False, traceback.format_exc())
+        else:
+            done_callback(True, result)
+
+    monkeypatch.setattr(utils, "run_in_thread", func)
 
 
 @pytest.mark.pastebin_test


### PR DESCRIPTION
Refreshing the directory tree happens quite often, and it usually takes between 50ms and 100ms each time. Running git is the bottleneck of refreshing, and letting 2 gits run at the same time (if you have 2 cpu cores) should help. Python's GIL doesn't affect this, because gits run in subprocesses.