### PR TITLE
Minimap cursor improvement

### DIFF
--- a/porcupine/plugins/minimap.py
+++ b/porcupine/plugins/minimap.py
@@ -34,6 +34,7 @@ class MiniMap(tkinter.Text):
             takefocus=False,
             yscrollcommand=self._update_vast,
             wrap="none",
+            cursor="arrow",
         )
 
         self._tab = tab


### PR DESCRIPTION
Not a big improvement, but the `xterm` cursor just looks strange in the minimap.