### PR TITLE
support port numbers and ips in urls

### DIFF
--- a/porcupine/plugins/urls.py
+++ b/porcupine/plugins/urls.py
@@ -14,7 +14,7 @@ def find_urls(text: tkinter.Text, start: str, end: str) -> Iterable[Tuple[str, s
     match_ends_and_search_begins = start
     while True:
         match_start = text.search(
-            r"\mhttps?://[a-z]", match_ends_and_search_begins, end, nocase=True, regexp=True
+            r"\mhttps?://[a-z0-9:]", match_ends_and_search_begins, end, nocase=True, regexp=True
         )
         if not match_start:  # empty string means not found
             break

--- a/tests/test_urls_plugin.py
+++ b/tests/test_urls_plugin.py
@@ -10,6 +10,7 @@ def test_find_urls():
         "https://github.com/Akuli/porcupine/",
         "http://example.com/",
         "http://example.com/comma,stuff",
+        "http://127.0.0.1:12345/foo.html",
     ]
     test_cases = """\
           URL


### PR DESCRIPTION
Fixes #565 

Apparently ipv6 address can have `[ ]` https://superuser.com/a/367788 not gonna support now