### PR TITLE
comment_block plugin: distinguish '# foo' with one vs many spaces

### DIFF
--- a/porcupine/plugins/comment_block.py
+++ b/porcupine/plugins/comment_block.py
@@ -13,12 +13,6 @@ from typing import Optional
 from porcupine import get_tab_manager, menubar, tabs, textutils
 
 
-def is_commented(line: str, comment_prefix: str) -> bool:
-    # Don't ignore indented '#    blah', that is most likely by this plugin
-    # But ignore '# blah' comments because they are likely written by hand
-    return line.startswith(comment_prefix) and not re.match(r" [^ ]", line[len(comment_prefix) :])
-
-
 def comment_or_uncomment(tab: tabs.FileTab, pressed_key: str | None = None) -> str | None:
     comment_prefix = tab.settings.get("comment_prefix", Optional[str])
     if pressed_key is not None and pressed_key != comment_prefix:
@@ -42,7 +36,9 @@ def comment_or_uncomment(tab: tabs.FileTab, pressed_key: str | None = None) -> s
         for lineno, line in enumerate(
             tab.textwidget.get(f"{start}.0", f"{end}.0").splitlines(), start
         )
-        if is_commented(line, comment_prefix)
+        # Don't ignore indented '#    blah', that is most likely by this plugin
+        # But ignore '# blah' comments because they are likely written by hand
+        if line.startswith(comment_prefix) and not re.match(r" [^ ]", line[len(comment_prefix) :])
     }
 
     with textutils.change_batch(tab.textwidget):

--- a/porcupine/plugins/comment_block.py
+++ b/porcupine/plugins/comment_block.py
@@ -36,8 +36,8 @@ def comment_or_uncomment(tab: tabs.FileTab, pressed_key: str | None = None) -> s
         for lineno, line in enumerate(
             tab.textwidget.get(f"{start}.0", f"{end}.0").splitlines(), start
         )
-        # Don't ignore indented '#    blah', that is most likely by this plugin
-        # But ignore '# blah' comments because they are likely written by hand
+        # Ignore '# blah' comments because they are likely written by hand
+        # But don't ignore indented '#    blah', that is most likely by this plugin
         if line.startswith(comment_prefix) and not re.match(r" [^ ]", line[len(comment_prefix) :])
     }
 

--- a/tests/test_comment_block_plugin.py
+++ b/tests/test_comment_block_plugin.py
@@ -65,7 +65,9 @@ def test_cant_uncomment_bug(filetab):
     filetab.textwidget.tag_add("sel", "3.8", "3.8 + 5 lines")
 
     filetab.textwidget.event_generate("<numbersign>")
-    assert filetab.textwidget.get("1.0", "end - 1 char") == """\
+    assert (
+        filetab.textwidget.get("1.0", "end - 1 char")
+        == """\
     def __init__(self, f):
         self._i_opened_the_file = None
 #        try:
@@ -75,9 +77,12 @@ def test_cant_uncomment_bug(filetab):
 #                f.close()
 #            raise
 """
+    )
 
     filetab.textwidget.event_generate("<numbersign>")
-    assert filetab.textwidget.get("1.0", "end - 1 char") == """\
+    assert (
+        filetab.textwidget.get("1.0", "end - 1 char")
+        == """\
     def __init__(self, f):
         self._i_opened_the_file = None
         try:
@@ -87,3 +92,4 @@ def test_cant_uncomment_bug(filetab):
                 f.close()
             raise
 """
+    )

--- a/tests/test_comment_block_plugin.py
+++ b/tests/test_comment_block_plugin.py
@@ -46,3 +46,44 @@ We select starting from this line
 To start of this line, so that the plugin shouldn't see this line as selected
 """
     )
+
+
+def test_cant_uncomment_bug(filetab):
+    filetab.textwidget.insert(
+        "1.0",
+        """\
+    def __init__(self, f):
+        self._i_opened_the_file = None
+        try:
+            self.initfp(f)
+        except:
+            if self._i_opened_the_file:
+                f.close()
+            raise
+""",
+    )
+    filetab.textwidget.tag_add("sel", "3.8", "3.8 + 5 lines")
+
+    filetab.textwidget.event_generate("<numbersign>")
+    assert filetab.textwidget.get("1.0", "end - 1 char") == """\
+    def __init__(self, f):
+        self._i_opened_the_file = None
+#        try:
+#            self.initfp(f)
+#        except:
+#            if self._i_opened_the_file:
+#                f.close()
+#            raise
+"""
+
+    filetab.textwidget.event_generate("<numbersign>")
+    assert filetab.textwidget.get("1.0", "end - 1 char") == """\
+    def __init__(self, f):
+        self._i_opened_the_file = None
+        try:
+            self.initfp(f)
+        except:
+            if self._i_opened_the_file:
+                f.close()
+            raise
+"""


### PR DESCRIPTION
Fixes #562