### PR TITLE
fix pluginmanager problems

### DIFF
--- a/porcupine/plugins/minimap.py
+++ b/porcupine/plugins/minimap.py
@@ -34,6 +34,7 @@ class MiniMap(tkinter.Text):
             takefocus=False,
             yscrollcommand=self._update_vast,
             wrap="none",
+            cursor="arrow",
         )
 
         self._tab = tab

--- a/porcupine/plugins/pluginmanager.py
+++ b/porcupine/plugins/pluginmanager.py
@@ -49,15 +49,23 @@ class PluginDialogContent:
     def __init__(self, master: tkinter.Misc) -> None:
         self.content_frame = ttk.Frame(master)
 
-        panedwindow = ttk.Panedwindow(self.content_frame, orient="horizontal")
+        _cols_width = [120, 150, 180]
+
+        # borrowed code from textutils.create_passive_text_widget
+        ttk_bg = self.content_frame.tk.eval("ttk::style lookup TLabel.label -background")
+        if not ttk_bg:
+            ttk_bg = "white"
+
+        panedwindow = tkinter.PanedWindow(self.content_frame, orient="horizontal", bg=ttk_bg)
         panedwindow.pack(side="top", fill="both", expand=True)
+
         self._plz_restart_label = ttk.Label(self.content_frame)
         self._plz_restart_label.pack(side="bottom", fill="x")
 
         left_side = ttk.Frame(panedwindow)
-        right_side = ttk.Frame(panedwindow)
-        panedwindow.add(left_side)  # type: ignore[no-untyped-call]
-        panedwindow.add(right_side)  # type: ignore[no-untyped-call]
+        right_side = ttk.Frame(panedwindow, padding=10, width=10000)  # to shrink left_side
+        panedwindow.add(left_side, minsize=sum(_cols_width))  # type: ignore[no-untyped-call]
+        panedwindow.add(right_side, minsize=250)  # type: ignore[no-untyped-call]
 
         self.treeview = ttk.Treeview(
             left_side, show="headings", columns=("name", "type", "status"), selectmode="extended"
@@ -79,42 +87,41 @@ class PluginDialogContent:
         self.treeview.pack(side="left", fill="both", expand=True)
         scrollbar.pack(side="right", fill="y")
 
-        for index, width in enumerate([100, 150, 180]):
+        for index, width in enumerate(_cols_width):
             self.treeview.column(index, width=width, minwidth=width)
 
-        self.treeview.heading(0, text="Name")
-        self.treeview.heading(1, text="Type")
-        self.treeview.heading(2, text="Status")
+        for index, header_title in enumerate(["Name", "Type", "Status"]):  # be consistent
+            self.treeview.heading(index, text=header_title)
+
         self._insert_data()
         self._update_plz_restart_label()
 
         # Must pack everything else before description label so that if
         # description is very long, it doesn't cover up other things
         self._title_label = ttk.Label(right_side, font=("", 15, "bold"))
-        self._title_label.pack(side="top", pady=5)
+        self._title_label.pack(side="top", pady=(0, 10))
         button_frame = ttk.Frame(right_side)
         button_frame.pack(side="bottom", fill="x")
 
         self.enable_button = ttk.Button(
-            button_frame, text="Enable", command=partial(self._set_enabled, True)
+            button_frame, text="Enable", command=partial(self._set_enabled, True), state="disabled"
         )
-        self.enable_button.pack(side="left", expand=True)
+        # here was an expand=True, but fill wasn't, it looks better with fill
+        self.enable_button.pack(side="left", expand=True, fill="x", padx=(0, 5))
+
         self.disable_button = ttk.Button(
-            button_frame, text="Disable", command=partial(self._set_enabled, False)
+            button_frame,
+            text="Disable",
+            command=partial(self._set_enabled, False),
+            state="disabled",
         )
-        self.disable_button.pack(side="left", expand=True)
+        self.disable_button.pack(side="left", expand=True, fill="x", padx=(5, 0))
 
         self.description = textutils.create_passive_text_widget(right_side)
-        self._set_description("Please select a plugin.")
+        self._set_description(
+            "No plugin selected. Select one or more from the list to disable or enable it."
+        )
         self.description.pack(fill="both", expand=True)
-
-        # I had some trouble getting this to work. With after_idle, this makes
-        # the left side invisibly small. With 50ms timeout, it still happened
-        # sometimes.
-        #
-        # FIXME: still happens sometimes, but very rarely, more timeout is not
-        # good because it causes slowness
-        panedwindow.after(100, lambda: panedwindow.sashpos(0, round(0.7 * DIALOG_WIDTH)))
 
     def _set_description(self, text: str) -> None:
         self.description.config(state="normal")

--- a/porcupine/plugins/pluginmanager.py
+++ b/porcupine/plugins/pluginmanager.py
@@ -90,7 +90,7 @@ class PluginDialogContent:
         for index, width in enumerate(_cols_width):
             self.treeview.column(index, width=width, minwidth=width)
 
-        for index, header_title in enumerate(["Name", "Type", "Status"]):  # be consistent
+        for index, header_title in enumerate(["Name", "Type", "Status"]):
             self.treeview.heading(index, text=header_title)
 
         self._insert_data()

--- a/tests/test_pluginmanager.py
+++ b/tests/test_pluginmanager.py
@@ -45,6 +45,7 @@ def test_enable_disable_multiple(dialog_content):
 def test_disable_itself(mocker, dialog_content):
     mock = mocker.patch("tkinter.messagebox.askokcancel", return_value=False)
     dialog_content.treeview.selection_set(["pluginmanager"])
+    dialog_content.disable_button.state(["!disabled"])
     dialog_content.disable_button.invoke()
     mock.assert_called_once()
     assert "settings.json" in str(mock.call_args)

--- a/tests/test_pluginmanager.py
+++ b/tests/test_pluginmanager.py
@@ -45,7 +45,7 @@ def test_enable_disable_multiple(dialog_content):
 def test_disable_itself(mocker, dialog_content):
     mock = mocker.patch("tkinter.messagebox.askokcancel", return_value=False)
     dialog_content.treeview.selection_set(["pluginmanager"])
-    dialog_content.disable_button.state(["!disabled"])
+    dialog_content.treeview.event_generate("<<TreeviewSelect>>")
     dialog_content.disable_button.invoke()
     mock.assert_called_once()
     assert "settings.json" in str(mock.call_args)


### PR DESCRIPTION
Fix treeview collapsing by switching to `tkinter.PanedWindow`, set panedwindow bg to ttk style, set minsize to panes, little margin around buttons, disabled button state by default (because it was annoying, that you can disable unselected plugins).