### PR TITLE
Find area improvements

### DIFF
--- a/porcupine/plugins/find.py
+++ b/porcupine/plugins/find.py
@@ -186,14 +186,11 @@ class Finder(ttk.Frame):
         # "find_highlight_selected". Both have to match.
         locations = [str(loc) for loc in self._textwidget.tag_ranges("sel")]
         locations2 = [str(loc) for loc in self._textwidget.tag_ranges("find_highlight_selected")]
-        if (
+        replace_this_state = "normal" if (
             locations == locations2
             and len(locations) == 2
             and tuple(locations) in self.get_match_ranges()
-        ):
-            replace_this_state = "normal"
-        else:
-            replace_this_state = "disabled"
+        ) else "disabled"
 
         self.previous_button.config(state=matches_something_state)
         self.next_button.config(state=matches_something_state)

--- a/porcupine/plugins/find.py
+++ b/porcupine/plugins/find.py
@@ -137,7 +137,7 @@ class Finder(ttk.Frame):
         entry.grid(row=row, column=1, sticky="we")
         return entry
 
-    def _toggle_var(self, var: tkinter.BooleanVar, junk: object) -> Literal["break"]:
+    def _toggle_var(self, var: tkinter.BooleanVar, junk: object) -> str:
         var.set(not var.get())
         return "break"
 
@@ -276,6 +276,7 @@ class Finder(ttk.Frame):
         # this was invoked through key binding
         pairs = self.get_match_ranges()
         if pairs:
+            operator: Literal[">=", ">"]
             if str(self.replace_this_button["state"]) == "disabled":
                 # No matches highlighted, can highlight match exactly at cursor
                 # Applies only to next match, previous always search before cursor
@@ -303,7 +304,7 @@ class Finder(ttk.Frame):
             index = next(possible_indexes, len(pairs) - 1)
             self._select_match(pairs, index)
 
-    def _replace_this(self, junk: object = None) -> Literal["break"]:
+    def _replace_this(self, junk: object = None) -> str:
         if str(self.replace_this_button["state"]) == "disabled":
             self.statuslabel.config(text='Click "Previous match" or "Next match" first.')
             return "break"
@@ -329,7 +330,7 @@ class Finder(ttk.Frame):
             self.statuslabel.config(text=f"Replaced a match. There are {left} more matches.")
         return "break"
 
-    def _replace_all(self, junk: object = None) -> Literal["break"]:
+    def _replace_all(self, junk: object = None) -> str:
         match_ranges = self.get_match_ranges()
 
         with textutils.change_batch(self._textwidget):

--- a/porcupine/plugins/find.py
+++ b/porcupine/plugins/find.py
@@ -276,7 +276,7 @@ class Finder(ttk.Frame):
         # this was invoked through key binding
         pairs = self.get_match_ranges()
         if pairs:
-            # If no matches highlighted, can highlight match exactly at cursor
+            # If no matches highlighted yet, can highlight match exactly at cursor
             # Applies only to next match, previous always search before cursor
             some_match_already_highlighted = str(self.replace_this_button["state"]) == "normal"
             operator: Literal[">=", ">"] = ">" if some_match_already_highlighted else ">="

--- a/porcupine/plugins/find.py
+++ b/porcupine/plugins/find.py
@@ -276,13 +276,10 @@ class Finder(ttk.Frame):
         # this was invoked through key binding
         pairs = self.get_match_ranges()
         if pairs:
-            operator: Literal[">=", ">"]
-            if str(self.replace_this_button["state"]) == "disabled":
-                # No matches highlighted, can highlight match exactly at cursor
-                # Applies only to next match, previous always search before cursor
-                operator = ">="
-            else:
-                operator = ">"
+            # If no matches highlighted, can highlight match exactly at cursor
+            # Applies only to next match, previous always search before cursor
+            some_match_already_highlighted = str(self.replace_this_button["state"]) == "normal"
+            operator: Literal[">=", ">"] = ">" if some_match_already_highlighted else ">="
 
             # find first pair that starts after the cursor, or cycle back to first
             possible_indexes = (

--- a/porcupine/plugins/find.py
+++ b/porcupine/plugins/find.py
@@ -276,11 +276,18 @@ class Finder(ttk.Frame):
         # this was invoked through key binding
         pairs = self.get_match_ranges()
         if pairs:
+            if str(self.replace_this_button["state"]) == "disabled":
+                # No matches highlighted, can highlight match exactly at cursor
+                # Applies only to next match, previous always search before cursor
+                operator = ">="
+            else:
+                operator = ">"
+
             # find first pair that starts after the cursor, or cycle back to first
             possible_indexes = (
                 i
                 for i, (start, end) in enumerate(pairs)
-                if self._textwidget.compare(start, ">", "insert")
+                if self._textwidget.compare(start, operator, "insert")
             )
             index = next(possible_indexes, 0)
             self._select_match(pairs, index)

--- a/porcupine/plugins/find.py
+++ b/porcupine/plugins/find.py
@@ -186,11 +186,15 @@ class Finder(ttk.Frame):
         # "find_highlight_selected". Both have to match.
         locations = [str(loc) for loc in self._textwidget.tag_ranges("sel")]
         locations2 = [str(loc) for loc in self._textwidget.tag_ranges("find_highlight_selected")]
-        replace_this_state = "normal" if (
-            locations == locations2
-            and len(locations) == 2
-            and tuple(locations) in self.get_match_ranges()
-        ) else "disabled"
+        replace_this_state = (
+            "normal"
+            if (
+                locations == locations2
+                and len(locations) == 2
+                and tuple(locations) in self.get_match_ranges()
+            )
+            else "disabled"
+        )
 
         self.previous_button.config(state=matches_something_state)
         self.next_button.config(state=matches_something_state)

--- a/tests/test_find_plugin.py
+++ b/tests/test_find_plugin.py
@@ -434,3 +434,26 @@ def test_replace_this_greyed_out(filetab_and_finder):
 
     finder.replace_entry.insert("end", "baz")
     assert str(finder.replace_this_button["state"]) == "disabled"
+
+
+def test_find_next_corner_case(filetab_and_finder):
+    filetab, finder = filetab_and_finder
+    filetab.textwidget.insert("end", "foo bar foo")
+    filetab.textwidget.mark_set("insert", "1.0")
+    finder.show()
+    finder.find_entry.insert("end", "foo")
+
+    # Go to first foo, cursor already at start of it
+    finder.next_button.invoke()
+    assert filetab.textwidget.index("find_highlight_selected.first") == "1.0"
+    assert filetab.textwidget.index("find_highlight_selected.last") == "1.3"
+
+    # But then move on to second foo, even though cursor hasn't moved
+    finder.next_button.invoke()
+    assert filetab.textwidget.index("find_highlight_selected.first") == "1.8"
+    assert filetab.textwidget.index("find_highlight_selected.last") == "1.11"
+
+    # And back to first
+    finder.next_button.invoke()
+    assert filetab.textwidget.index("find_highlight_selected.first") == "1.0"
+    assert filetab.textwidget.index("find_highlight_selected.last") == "1.3"

--- a/tests/test_find_plugin.py
+++ b/tests/test_find_plugin.py
@@ -213,6 +213,10 @@ def test_basic_statuses_and_previous_and_next_match_buttons(filetab_and_finder):
     flatten = itertools.chain.from_iterable
     assert list(map(str, tag_locations)) == list(flatten(selecteds))
 
+    finder.next_button.invoke()  # highlight first match
+    assert finder.statuslabel["text"] == "Match 1/5"
+    assert get_selected() == selecteds[0]
+
     index = 0
     for lol in range(500):  # many times back and forth to check corner cases
         if random.choice([True, False]):
@@ -223,7 +227,7 @@ def test_basic_statuses_and_previous_and_next_match_buttons(filetab_and_finder):
             index = (index + 1) % len(selecteds)
 
         assert finder.statuslabel["text"] == f"Match {index + 1}/5"
-        assert selecteds[index] == get_selected()
+        assert get_selected() == selecteds[index]
 
 
 def test_replace(filetab_and_finder):
@@ -434,26 +438,3 @@ def test_replace_this_greyed_out(filetab_and_finder):
 
     finder.replace_entry.insert("end", "baz")
     assert str(finder.replace_this_button["state"]) == "disabled"
-
-
-def test_find_next_corner_case(filetab_and_finder):
-    filetab, finder = filetab_and_finder
-    filetab.textwidget.insert("end", "foo bar foo")
-    filetab.textwidget.mark_set("insert", "1.0")
-    finder.show()
-    finder.find_entry.insert("end", "foo")
-
-    # Go to first foo, cursor already at start of it
-    finder.next_button.invoke()
-    assert filetab.textwidget.index("find_highlight_selected.first") == "1.0"
-    assert filetab.textwidget.index("find_highlight_selected.last") == "1.3"
-
-    # But then move on to second foo, even though cursor hasn't moved
-    finder.next_button.invoke()
-    assert filetab.textwidget.index("find_highlight_selected.first") == "1.8"
-    assert filetab.textwidget.index("find_highlight_selected.last") == "1.11"
-
-    # And back to first
-    finder.next_button.invoke()
-    assert filetab.textwidget.index("find_highlight_selected.first") == "1.0"
-    assert filetab.textwidget.index("find_highlight_selected.last") == "1.3"

--- a/tests/test_find_plugin.py
+++ b/tests/test_find_plugin.py
@@ -190,9 +190,8 @@ def test_basic_statuses_and_previous_and_next_match_buttons(filetab_and_finder):
         assert str(button["state"]) == "disabled"
 
     for button in [finder.previous_button, finder.next_button]:
-        finder.statuslabel.config(text="this should be overwritten")
-        click_disabled_button(button)
-        assert finder.statuslabel["text"] == "No matches found!"
+        click_disabled_button(button)  # shouldn't do anything
+        assert finder.statuslabel["text"] == "Found no matches :("
 
     finder.find_entry.delete(0, "end")
     finder.find_entry.insert(0, "asd")
@@ -201,9 +200,12 @@ def test_basic_statuses_and_previous_and_next_match_buttons(filetab_and_finder):
     assert finder.statuslabel["text"] == "Found 5 matches."
 
     def get_selected():
-        start, end = filetab.textwidget.tag_ranges("sel")
-        assert filetab.textwidget.index("insert") == str(start)
-        return (str(start), str(end))
+        start, end = map(str, filetab.textwidget.tag_ranges("sel"))
+        start2, end2 = map(str, filetab.textwidget.tag_ranges("find_highlight_selected"))
+        assert start == start2
+        assert end == end2
+        assert filetab.textwidget.index("insert") == start
+        return (start, end)
 
     selecteds = [("1.0", "1.3"), ("1.4", "1.7"), ("1.8", "1.11"), ("2.0", "2.3"), ("2.4", "2.7")]
 
@@ -220,7 +222,7 @@ def test_basic_statuses_and_previous_and_next_match_buttons(filetab_and_finder):
             finder.next_button.invoke()
             index = (index + 1) % len(selecteds)
 
-        assert finder.statuslabel["text"] == ""
+        assert finder.statuslabel["text"] == f"Match {index + 1}/5"
         assert selecteds[index] == get_selected()
 
 

--- a/tests/test_find_plugin.py
+++ b/tests/test_find_plugin.py
@@ -423,13 +423,11 @@ def test_replace_this_match(filetab_and_finder):
     assert filetab.textwidget.get("1.0", "end - 1 char") == "foo bar baz"
 
 
-@pytest.mark.xfail
 def test_replace_this_greyed_out(filetab_and_finder):
     filetab, finder = filetab_and_finder
     filetab.textwidget.insert("end", "foo bar foo")
     filetab.textwidget.mark_set("insert", "1.0")
     filetab.textwidget.tag_add("sel", "1.0", "1.3")  # Select foo so it goes to find entry
-    finder.find_entry.insert("end", "foo")
     finder.show()
 
     finder.replace_entry.insert("end", "baz")


### PR DESCRIPTION
- Fixes #479.
- Adds "Match 2/5" kind of thing when you click "Previous match" or "Next match".
- If cursor is at start of a match, but it isn't highlighted, then "Next match" will choose it instead of whatever comes after it.