### PR TITLE
tab title fix attempt

### DIFF
--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -556,8 +556,11 @@ bers.py>` use this attribute.
             string = self.textwidget.get("1.0", "end - 1 char")
         return hashlib.md5(string.encode("utf-8")).hexdigest()
 
-    def _set_saved_state(self, stat_result: Optional[os.stat_result]) -> None:
-        self._saved_state = (stat_result, self._get_char_count(), self._get_hash())
+    def _set_saved_state(self, state: tuple[os.stat_result, int, str] | os.stat_result | None) -> None:
+        if isinstance(state, tuple):
+            self._saved_state = state
+        else:
+            self._saved_state = (state, self._get_char_count(), self._get_hash())
         self._update_titles()
 
     def is_modified(self) -> bool:
@@ -649,7 +652,7 @@ bers.py>` use this attribute.
                 return True
 
             # Avoid reading file contents again soon
-            self._saved_state = (actual_stat, save_char_count, save_hash)
+            self._set_saved_state((actual_stat, save_char_count, save_hash))
             return False
 
         except (OSError, UnicodeError):
@@ -819,10 +822,7 @@ bers.py>` use this attribute.
         else:
             self = cls(manager, state.content, state.path)
 
-        # title depends on _saved_state
-        self._saved_state = state.saved_state
-        self._update_titles()
-
+        self._set_saved_state(state.saved_state)
         self.textwidget.mark_set("insert", state.cursor_pos)
         self.textwidget.see("insert linestart")
         return self

--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -556,7 +556,9 @@ bers.py>` use this attribute.
             string = self.textwidget.get("1.0", "end - 1 char")
         return hashlib.md5(string.encode("utf-8")).hexdigest()
 
-    def _set_saved_state(self, state: tuple[os.stat_result | None, int, str] | os.stat_result | None) -> None:
+    def _set_saved_state(
+        self, state: tuple[os.stat_result | None, int, str] | os.stat_result | None
+    ) -> None:
         if isinstance(state, tuple):
             self._saved_state = state
         else:

--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -529,6 +529,7 @@ bers.py>` use this attribute.
         self.scrollbar.config(command=self.textwidget.yview)
 
         self.textwidget.bind("<<ContentChanged>>", self._update_titles, add=True)
+        self.textwidget.bind("<<PathChanged>>", self._update_titles, add=True)
         self._update_titles()
 
     @classmethod
@@ -732,7 +733,6 @@ bers.py>` use this attribute.
 
         self._save_hash = self._get_hash()
         self.path = path
-        self._update_titles()
         self.event_generate("<<AfterSave>>")
         return True
 

--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -821,7 +821,7 @@ bers.py>` use this attribute.
         else:
             self = cls(manager, state.content, state.path)
 
-        self._set_saved_state(state.saved_state)
+        self._set_saved_state(state.saved_state)  # TODO: does this make any sense?
         self.textwidget.mark_set("insert", state.cursor_pos)
         self.textwidget.see("insert linestart")
         return self

--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -556,7 +556,7 @@ bers.py>` use this attribute.
             string = self.textwidget.get("1.0", "end - 1 char")
         return hashlib.md5(string.encode("utf-8")).hexdigest()
 
-    def _set_saved_state(self, state: tuple[os.stat_result, int, str] | os.stat_result | None) -> None:
+    def _set_saved_state(self, state: tuple[os.stat_result | None, int, str] | os.stat_result | None) -> None:
         if isinstance(state, tuple):
             self._saved_state = state
         else:


### PR DESCRIPTION
Fixes #439  (I think, can reopen if not)

I have seen #439 happening a few times, and I'm quite sure it's because `TabManager._update_tab_titles()` doesn't get called. Looking at the code, it gets called when:
- A tab is added.
- A tab is closed.
- A tab that is currently in the tab manager gets its `title_choices` changed.

The `title_choices` of a `FileTab` are set by `_update_titles()`. It uses the path of the tab and whether the file has been modified, so it should run when:
- Content changes (was already correct)
- Path changes (fixed)
- `_saved_state` changes (fixed)