### PR TITLE
python: do not autocomplete when dot is pressed

### DIFF
--- a/porcupine/default_filetypes.toml
+++ b/porcupine/default_filetypes.toml
@@ -183,7 +183,6 @@ tabs2spaces = true
 indent_size = 4
 max_line_length = 79   # pep8 says so, lol
 commands = {run = "{python} {file}"}
-autocomplete_chars = ["."]
 langserver = {command = "{porcupine_python} -m pyls", language_id = "python"}
 comment_prefix = '#'
 autoindent_regexes = {dedent = '(return|raise)( .+)?|break|pass|continue', indent = '.*:'}


### PR DESCRIPTION
"Temporary" workaround for #141 so that when writing `Full sentences.`, it doesn't try to autocomplete