### PR TITLE
directory tree: use settings.add_option earlier

### DIFF
--- a/porcupine/plugins/directory_tree.py
+++ b/porcupine/plugins/directory_tree.py
@@ -542,9 +542,8 @@ def setup() -> None:
         label="Focus directory tree", command=partial(focus_treeview, tree)
     )
 
-    string_paths = settings.get("directory_tree_projects", List[str])
-
     # Must reverse because last added project goes first
+    string_paths = settings.get("directory_tree_projects", List[str])
     for path in map(Path, string_paths[:MAX_PROJECTS][::-1]):
         if path.is_absolute() and path.is_dir():
             tree.add_project(path, refresh=False)

--- a/porcupine/plugins/directory_tree.py
+++ b/porcupine/plugins/directory_tree.py
@@ -517,6 +517,8 @@ def on_any_widget_focused(tree: DirectoryTree, event: tkinter.Event[tkinter.Misc
 
 
 def setup() -> None:
+    settings.add_option("directory_tree_projects", [], List[str])
+
     # TODO: add something for finding a file by typing its name?
     container = ttk.Frame(get_paned_window())
 
@@ -540,7 +542,6 @@ def setup() -> None:
         label="Focus directory tree", command=partial(focus_treeview, tree)
     )
 
-    settings.add_option("directory_tree_projects", [], List[str])
     string_paths = settings.get("directory_tree_projects", List[str])
 
     # Must reverse because last added project goes first


### PR DESCRIPTION
Prevents getting an error when loading directory tree from plugin manager