### PR TITLE
default key bindings: do nothing with shift+control+backspace in beginning of file

### DIFF
--- a/porcupine/default_keybindings.tcl
+++ b/porcupine/default_keybindings.tcl
@@ -131,13 +131,11 @@ bind Text <$contmand-Delete> {
 
 bind Text <BackSpace> {
     try {%W delete sel.first sel.last} on error {} {
-        if {[%W index insert] != 1.0} {
-            set beforecursor [%W get {insert linestart} insert]
-            if {[bind %W <<Dedent>>] != "" && $beforecursor != "" && [string is space $beforecursor]} {
-                event generate %W <<Dedent>>
-            } else {
-                %W delete {insert - 1 char}
-            }
+        set beforecursor [%W get {insert linestart} insert]
+        if {[bind %W <<Dedent>>] != "" && $beforecursor != "" && [string is space $beforecursor]} {
+            event generate %W <<Dedent>>
+        } else {
+            %W delete {insert - 1 char} insert
         }
     }
 }
@@ -163,7 +161,7 @@ bind Text <Shift-$contmand-Delete> {
 bind Text <Shift-$contmand-BackSpace> {
     try {%W delete sel.first sel.last} on error {} {
         if {[%W index insert] == [%W index {insert linestart}]} {
-            %W delete {insert - 1 char}
+            %W delete {insert - 1 char} insert
         } else {
             %W delete {insert linestart} insert
         }

--- a/tests/test_default_keybindings.py
+++ b/tests/test_default_keybindings.py
@@ -1,9 +1,21 @@
-def test_backspace_in_beginning_of_file(filetab):
+import sys
+
+import pytest
+
+
+if sys.platform == "darwin":
+    contmand_shift_backspace = "<Command-Shift-BackSpace>"
+else:
+    contmand_shift_backspace = "<Control-Shift-BackSpace>"
+
+
+@pytest.mark.parametrize("event_string", ["<BackSpace>", contmand_shift_backspace])
+def test_backspace_in_beginning_of_file(filetab, event_string):
     filetab.textwidget.insert("end", "a")
     filetab.textwidget.mark_set("insert", "1.0")
-    filetab.textwidget.event_generate("<BackSpace>")
+    filetab.textwidget.event_generate(event_string)
     assert filetab.textwidget.get("1.0", "end - 1 char") == "a"
 
     filetab.textwidget.tag_add("sel", "1.0", "1.1")
-    filetab.textwidget.event_generate("<BackSpace>")
+    filetab.textwidget.event_generate(event_string)
     assert filetab.textwidget.get("1.0", "end - 1 char") == ""

--- a/tests/test_default_keybindings.py
+++ b/tests/test_default_keybindings.py
@@ -2,7 +2,6 @@ import sys
 
 import pytest
 
-
 if sys.platform == "darwin":
     contmand_shift_backspace = "<Command-Shift-BackSpace>"
 else:

--- a/tests/test_indent_dedent.py
+++ b/tests/test_indent_dedent.py
@@ -1,4 +1,4 @@
-import platform
+import sys
 
 import pytest
 
@@ -104,7 +104,7 @@ def test_autoindent(filetab):
 
 
 # FIXME: figure out how to do this on mac
-@pytest.mark.skipif(platform.system() == "Darwin", reason="I don't have a mac")
+@pytest.mark.skipif(sys.platform == "darwin", reason="I don't have a mac")
 def test_shift_enter_and_alt_enter(filetab):
     # See issue #404 (not the HTTP status, lol)
     indent = " " * 4


### PR DESCRIPTION
Fixes #630 