### PR TITLE
anchors plugin: fix for files with up to 9999 lines

### DIFF
--- a/porcupine/plugins/anchors.py
+++ b/porcupine/plugins/anchors.py
@@ -19,9 +19,7 @@ class AnchorManager:
         self.tab_textwidget = tab_textwidget
         self.linenumbers = linenumbers
 
-        self.anchor_symbol = "¶"
-
-        # tkinter have default marks such as "insert", "current", "tkinter::anchor1"
+        # tkinter have default marks such as "insert", "current", "tk::anchor1"
         self.custom_anchor_prefix = "anchor_"
 
         linenumbers.bind("<<Updated>>", self.update_linenumbers, add=True)
@@ -96,9 +94,7 @@ class AnchorManager:
         """
         self.prevent_duplicate_anchors()
 
-        anchor_list = self._get_anchors()
-
-        for anchorpoint in anchor_list:
+        for anchorpoint in self._get_anchors():
             row_tag = "line_" + self.tab_textwidget.index(anchorpoint).split(".")[0]
             try:
                 [row_id] = self.linenumbers.find_withtag(row_tag)
@@ -106,7 +102,7 @@ class AnchorManager:
                 pass
             else:
                 row_text = self.linenumbers.itemcget(row_id, "text")  # type: ignore[no-untyped-call]
-                self.linenumbers.itemconfigure(row_id, text=row_text + " " + self.anchor_symbol)
+                self.linenumbers.itemconfigure(row_id, text=row_text + "¶")
 
     def prevent_duplicate_anchors(self) -> None:
         current_rows = set()

--- a/porcupine/plugins/linenumbers.py
+++ b/porcupine/plugins/linenumbers.py
@@ -61,7 +61,7 @@ class LineNumbers(tkinter.Canvas):
             self.create_text(
                 0,
                 y,
-                text=f" {lineno}",
+                text=f" {lineno:<4}",
                 anchor="nw",
                 font="TkFixedFont",
                 fill=self._text_color,


### PR DESCRIPTION
Fixes #639 

If you edit a file that contains 10000 or more lines, this will not work.

To prevent further issues like that, the linenumbers plugin now appends spaces to make all numbers 4 characters wide, plus an initial leading space that it has appeneded before too. So a line number 123 is now shown as `" 123 "`, same width as `" 1234"`, and an anchor symbol added to the end will always go to the same place.