### PR TITLE
speed up windows build by avoiding unnecessary pip install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: "3.8"  # last version supporting windows 7
-    - run: pip install $(grep requests requirements.txt)
+    - run: pip install $(grep requests requirements-dev.txt)
     - run: pip install -r requirements.txt
     - uses: egor-tensin/setup-mingw@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,8 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: "3.8"  # last version supporting windows 7
-    - run: pip install -r requirements.txt -r requirements-dev.txt
+    - run: pip install $(grep requests requirements.txt)
+    - run: pip install -r requirements.txt
     - uses: egor-tensin/setup-mingw@v2
       with:
         platform: x64


### PR DESCRIPTION
Windows build is currently the slowest thing in CI.