### PR TITLE
use actual encoding for content hash

### DIFF
--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -742,7 +742,7 @@ bers.py>` use this attribute.
             self._set_saved_state((actual_stat, save_char_count, save_hash))
             return False
 
-        except (OSError, UnicodeError):
+        except OSError:
             log.exception(
                 f"error when figuring out if '{self.path}' needs reloading, assuming it does"
             )

--- a/tests/test_tabs.py
+++ b/tests/test_tabs.py
@@ -1,6 +1,6 @@
 import os
 
-from porcupine import tabs
+from porcupine import settings, tabs
 
 
 def test_filetab_path_gets_resolved(tmp_path, tabmanager):
@@ -120,6 +120,14 @@ def test_other_program_changed_file(filetab, tmp_path):
 
     (tmp_path / "foo.py").write_text("lol\n")
     assert not filetab.other_program_changed_file()
+
+
+def test_changing_newline_mode_affects_unsaved_changes(tabmanager, tmp_path):
+    (tmp_path / "foo.py").write_bytes(b"lol\n")
+    tab = tabmanager.open_file(tmp_path / "foo.py")
+    assert not tab.has_unsaved_changes()
+    tab.settings.set("line_ending", settings.LineEnding.CRLF)
+    assert tab.has_unsaved_changes()
 
 
 def test_save_as(filetab, tmp_path):


### PR DESCRIPTION
Code is a bit longer because we need to figure out what Python would write into the file with the current settings, but this has a couple advantages:
- If you change the encoding in Porcupine (not possible yet), the file should show up as changed until it is saved
- `FileTab.other_program_changed_file()` no longer has to handle `UnicodeError`, all error handling is now related to #680 

Todo:
- [x] Fixes #685 add test