### PR TITLE
github actions: add timeouts to tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,6 +24,7 @@ jobs:
         time mypy --platform darwin --python-version 3.8 porcupine more_plugins docs/extensions.py
         time mypy --platform darwin --python-version 3.9 porcupine more_plugins docs/extensions.py
   pytest-windows:
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9"]
@@ -39,6 +40,7 @@ jobs:
     - run: python scripts/download-tkdnd.py
     - run: python -m pytest -vvvv --durations=10
   pytest-linux:
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9"]
@@ -55,6 +57,7 @@ jobs:
       with:
         run: python3 -m pytest -vvvv --durations=10
   pytest-macos:
+    timeout-minutes: 10
     # https://github.com/actions/setup-python/issues/58
     # Brew-installed python 3.8 and 3.9 seem to already be there, so it's not slow
     # but starting today, 3.9 has no tkinter lol?


### PR DESCRIPTION
Not only for #379 but also because I sometimes make tests frozen by messing up with the tests. For example, if I forget to mock a function that shows a dialog to the user.