### PR TITLE
git_status plugin: fix slowness in projects with many ignored files

### DIFF
--- a/porcupine/plugins/git_status.py
+++ b/porcupine/plugins/git_status.py
@@ -78,16 +78,16 @@ class ProjectColorer:
         self.tree = tree
         self.project_id = project_id
         self.project_path = get_path(project_id)
-        self.git_status_future: Future[dict[Path, str]] | None = None
         self.queue: set[str] = set()
+        self._git_status_future: Future[dict[Path, str]] | None = None
 
     def start_running_git_status(self) -> None:
-        self.git_status_future = git_pool.submit(partial(run_git_status, self.project_path))
+        self._git_status_future = git_pool.submit(partial(run_git_status, self.project_path))
 
         # Handle queue contents when it has completed
         def check() -> None:
-            if self.git_status_future is not None:
-                if self.git_status_future.done():
+            if self._git_status_future is not None:
+                if self._git_status_future.done():
                     self._handle_queue()
                 else:
                     self.tree.after(25, check)
@@ -95,17 +95,24 @@ class ProjectColorer:
         check()
 
     def stop(self) -> None:
-        self.git_status_future = None
+        self._git_status_future = None
 
     def _choose_tag(self, item_path: Path) -> str | None:
         # process should be done, result available immediately
-        assert self.git_status_future is not None
-        path_to_status = self.git_status_future.result(timeout=0)
+        assert self._git_status_future is not None
+        path_to_status = self._git_status_future.result(timeout=0)
 
-        for path, status in path_to_status.items():
-            # use status of a folder also for its contents
-            if path == item_path or path in item_path.parents:
-                return status
+        # path_to_status can be huge if lots of ignored files, avoid looping over it
+        try:
+            return path_to_status[item_path]
+        except KeyError:
+            # status of a folder applies to everything it contains
+            for folder in item_path.parents:
+                try:
+                    return path_to_status[folder]
+                except KeyError:
+                    if folder == self.project_path:
+                        break
 
         # Handle directories containing files with different statuses
         substatuses = {
@@ -155,8 +162,8 @@ class ProjectColorer:
 
     def color_children_now_or_later(self, parent_id: str) -> None:
         self.queue.add(parent_id)
-        assert self.git_status_future is not None
-        if self.git_status_future.done():
+        assert self._git_status_future is not None
+        if self._git_status_future.done():
             self._handle_queue()
 
 

--- a/porcupine/plugins/git_status.py
+++ b/porcupine/plugins/git_status.py
@@ -124,7 +124,7 @@ class ProjectColorer:
         # process should be done, result available immediately
         assert self._git_status_future is not None
         path_to_status = self._git_status_future.result(timeout=0)
-        return path_to_status.get(item_path)
+        return path_to_status.get(item_path, None)
 
     def _set_tag(self, item_id: str, git_tag: str | None) -> bool:
         old_tags = set(self.tree.item(item_id, "tags"))

--- a/porcupine/plugins/git_status.py
+++ b/porcupine/plugins/git_status.py
@@ -78,6 +78,8 @@ def run_git_status(project_root: Path) -> dict[Path, str]:
         if status in {"git_added", "git_modified", "git_mergeconflict"}:
             for folder in path.parents:
                 folder_to_content_statuses.setdefault(folder, set()).add(status)
+                if folder == project_root:
+                    break
 
     assert not (folder_to_content_statuses.keys() & result.keys())
 


### PR DESCRIPTION
Porcupine was behaving really slowly, like 5sec of unresponsiveness after clicking it. It only happened after opening a project named `~/tex`. It contains many ignored files, and looping through them for each directory tree item just isn't practical:
```
akuli@akuli-desktop:~/tex$ git status --porcelain | wc -l
1
akuli@akuli-desktop:~/tex$ git status --porcelain --ignored | wc -l
490
```
