### PR TITLE
directory tree: single-letter key bindings to avoid pressing arrow keys many times

### DIFF
--- a/porcupine/plugins/directory_tree.py
+++ b/porcupine/plugins/directory_tree.py
@@ -339,7 +339,25 @@ class DirectoryTree(ttk.Treeview):
             return result
         return None
 
-    # TODO: invoking context menu from keyboard
+    def _cycle_through_items(self, event: tkinter.Event[DirectoryTree]) -> None:
+        if len(event.char) != 1:
+            return
+
+        try:
+            [item] = self.selection()
+        except ValueError:  # nothing selected
+            return
+
+        children = [c for c in self.get_children(self.parent(item)) if self.item(c, 'text').startswith(event.char)]
+        if not children:
+            return
+
+        try:
+            index = (children.index(item) + 1) % len(children)
+        except ValueError:
+            index = 0
+        self.set_the_selection_correctly(children[index])
+
     def _on_right_click(self, event: tkinter.Event[DirectoryTree]) -> str | None:
         self.tk.call("focus", self)
 
@@ -432,7 +450,10 @@ def setup() -> None:
     tree.refresh()
 
     # TODO: mac right click = button 2?
+    # TODO: invoking context menu from keyboard
     tree.bind("<Button-3>", tree._on_right_click, add=True)
+
+    tree.bind("<Key>", partial(tree._cycle_through_items), add=True)
 
 
 # Used in other plugins

--- a/porcupine/plugins/directory_tree.py
+++ b/porcupine/plugins/directory_tree.py
@@ -348,7 +348,11 @@ class DirectoryTree(ttk.Treeview):
         except ValueError:  # nothing selected
             return
 
-        children = [c for c in self.get_children(self.parent(item)) if self.item(c, 'text').startswith(event.char)]
+        children = [
+            c
+            for c in self.get_children(self.parent(item))
+            if self.item(c, "text").startswith(event.char)
+        ]
         if not children:
             return
 

--- a/porcupine/plugins/directory_tree.py
+++ b/porcupine/plugins/directory_tree.py
@@ -356,7 +356,9 @@ class DirectoryTree(ttk.Treeview):
             index = (children.index(item) + 1) % len(children)
         except ValueError:
             index = 0
+
         self.set_the_selection_correctly(children[index])
+        self.see(children[index])
 
     def _on_right_click(self, event: tkinter.Event[DirectoryTree]) -> str | None:
         self.tk.call("focus", self)

--- a/tests/test_directory_tree_plugin.py
+++ b/tests/test_directory_tree_plugin.py
@@ -205,3 +205,5 @@ def test_cycling_through_items(tree, tmp_path, tabmanager):
     assert get_path(tree.selection()[0]) == tmp_path / "README"
     tree.event_generate("R")
     assert get_path(tree.selection()[0]) == tmp_path / "README"
+    tree.event_generate("x")
+    assert get_path(tree.selection()[0]) == tmp_path / "README"

--- a/tests/test_directory_tree_plugin.py
+++ b/tests/test_directory_tree_plugin.py
@@ -177,3 +177,31 @@ def test_home_folder_displaying():
     assert _stringify_path(Path.home()) == "~"
     assert _stringify_path(Path.home() / "lol") in ["~/lol", r"~\lol"]
     assert "~" not in _stringify_path(Path.home().parent / "asdfggg")
+
+
+def test_cycling_through_items(tree, tmp_path, tabmanager):
+    (tmp_path / "README").touch()
+    (tmp_path / "foo.txt").touch()
+    (tmp_path / "bar.txt").touch()
+    (tmp_path / "baz.txt").touch()
+
+    tree.add_project(tmp_path)
+    [project_id] = [id for id in tree.get_children("") if get_path(id) == tmp_path]
+    open_as_if_user_clicked(tree, project_id)
+    open_as_if_user_clicked(tree, tree.get_children(project_id)[0])
+
+    tree.update()
+    tree.focus_force()
+
+    tree.event_generate("f")
+    assert get_path(tree.selection()[0]) == tmp_path / "foo.txt"
+    tree.event_generate("b")
+    assert get_path(tree.selection()[0]) == tmp_path / "bar.txt"
+    tree.event_generate("b")
+    assert get_path(tree.selection()[0]) == tmp_path / "baz.txt"
+    tree.event_generate("b")
+    assert get_path(tree.selection()[0]) == tmp_path / "bar.txt"
+    tree.event_generate("R")
+    assert get_path(tree.selection()[0]) == tmp_path / "README"
+    tree.event_generate("R")
+    assert get_path(tree.selection()[0]) == tmp_path / "README"


### PR DESCRIPTION
fixes #564 