### PR TITLE
git status: handle error if git is really slow

### DIFF
--- a/porcupine/plugins/git_status.py
+++ b/porcupine/plugins/git_status.py
@@ -50,7 +50,7 @@ def run_git_status(project_root: Path) -> dict[Path, str]:
             log.debug(f"git status failed in {project_root}: {run_result}")
             return {}
 
-    except (OSError, UnicodeError):
+    except (OSError, UnicodeError, subprocess.TimeoutExpired):
         log.warning("can't run git", exc_info=True)
         return {}
 


### PR DESCRIPTION
Didn't cause problems in practice, but might as well do it correctly.