### PR TITLE
delete old PYTHONPATH hack

### DIFF
--- a/porcupine/plugins/run/windows_run.py
+++ b/porcupine/plugins/run/windows_run.py
@@ -14,7 +14,7 @@ colorama.init()
 prog, directory, command = sys.argv
 print(colorama.Fore.BLUE + command + colorama.Fore.RESET)
 try:
-    returncode: int | None = subprocess.call(command, cwd=directory, env=new_env, shell=True)
+    returncode: int | None = subprocess.call(command, cwd=directory, shell=True)
 except KeyboardInterrupt:
     # the subprocess should have already printed any traceback or
     # whatever it might want to print

--- a/porcupine/plugins/run/windows_run.py
+++ b/porcupine/plugins/run/windows_run.py
@@ -4,22 +4,12 @@
 # This should always run in the same python that Porcupine uses.
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 
 import colorama
 
 colorama.init()
-
-# When installed from the exe installer, python finds its modules with
-# PYTHONPATH. We don't want to pass it on to the user's command, because it
-# should run with the user's own Python, not Porcupine's python.
-new_env = dict(os.environ)
-try:
-    del new_env["PYTHONPATH"]
-except KeyError:
-    pass
 
 prog, directory, command = sys.argv
 print(colorama.Fore.BLUE + command + colorama.Fore.RESET)


### PR DESCRIPTION
Should no longer be needed, because we are not using pynsist and its `PYTHONPATH` magic. The windows installer now works differently and places the modules to where Python imports from by default.

Fixes #795