### PR TITLE
mac mouse wheel click

### DIFF
--- a/porcupine/default_keybindings.tcl
+++ b/porcupine/default_keybindings.tcl
@@ -59,9 +59,11 @@ for {set i 1} {$i <= 9} {incr i} {
 
 # tab_closing plugin
 event add "<<TabClosing:XButtonClickClose>>" <Button-1>
-# no wheel click on mac (afaik)
-if {[tk windowingsystem] != "aqua"} {
-    # Wheel-click is Button-2
+if {[tk windowingsystem] == "aqua"} {
+    # Wheel click on mac is Button-3
+    event add "<<TabClosing:HeaderClickClose>>" <Button-3>
+} else {
+     # Wheel-click is Button-2
     event add "<<TabClosing:HeaderClickClose>>" <Button-2>
 }
 

--- a/porcupine/default_keybindings.tcl
+++ b/porcupine/default_keybindings.tcl
@@ -4,9 +4,11 @@
 if {[tk windowingsystem] == "aqua"} {
     set contmand Command
     event add "<<RightClick>>" <Button-2>
+    event add "<<WheelClick>>" <Button-3>
 } else {
     set contmand Control
     event add "<<RightClick>>" <Button-3>
+    event add "<<WheelClick>>" <Button-2>
 }
 
 event add "<<Menubar:File/New File>>" <$contmand-n>
@@ -59,13 +61,6 @@ for {set i 1} {$i <= 9} {incr i} {
 
 # tab_closing plugin
 event add "<<TabClosing:XButtonClickClose>>" <Button-1>
-if {[tk windowingsystem] == "aqua"} {
-    # Wheel click on mac is Button-3
-    event add "<<TabClosing:HeaderClickClose>>" <Button-3>
-} else {
-     # Wheel-click is Button-2
-    event add "<<TabClosing:HeaderClickClose>>" <Button-2>
-}
 
 # sort plugin
 event add "<<Menubar:Edit/Sort Lines>>" <Alt-s>

--- a/porcupine/plugins/tab_closing.py
+++ b/porcupine/plugins/tab_closing.py
@@ -69,4 +69,4 @@ def setup() -> None:
     )
     tabmanager.bind("<<TabClosing:XButtonClickClose>>", on_x_clicked, add=True)
     tabmanager.bind("<<RightClick>>", show_menu, add=True)
-    tabmanager.bind("<<TabClosing:HeaderClickClose>>", on_header_clicked, add=True)
+    tabmanager.bind("<<WheelClick>>", on_header_clicked, add=True)


### PR DESCRIPTION
I have replaced the `TabClosing:HeaderClickClose` by `<<WheelClick>>` binding who will set the mouse button to 2 if it is mac, else 3.
The tab closing plugin has been updated accordingly.
# Referenced issues
#303 