### PR TITLE
Link cleanup

### DIFF
--- a/porcupine/plugins/aboutdialog.py
+++ b/porcupine/plugins/aboutdialog.py
@@ -44,7 +44,7 @@ def get_link_opener(match: re.Match[str]) -> Callable[[], object]:
         return lambda: webbrowser.open(url)
 
     path = Path(match.group(1))
-    assert path.is_dir()
+    assert path.is_dir(), path
 
     # early returns don't work https://github.com/python/mypy/issues/10773
     if sys.platform == "win32":

--- a/porcupine/plugins/aboutdialog.py
+++ b/porcupine/plugins/aboutdialog.py
@@ -46,12 +46,13 @@ def get_link_opener(match: re.Match[str]) -> Callable[[], object]:
     path = Path(match.group(1))
     assert path.is_dir()
 
-    # str() needed because mypy is awesome
-    if str(sys.platform) == "win32":
+    # early returns don't work https://github.com/python/mypy/issues/10773
+    if sys.platform == "win32":
         return lambda: os.startfile(path)
-    if str(sys.platform) == "darwin":
+    elif sys.platform == "darwin":
         return lambda: subprocess.Popen(["open", path])
-    return lambda: subprocess.Popen(["xdg-open", path])
+    else:
+        return lambda: subprocess.Popen(["xdg-open", path])
 
 
 def show_huge_logo(junk: object = None) -> None:

--- a/porcupine/plugins/aboutdialog.py
+++ b/porcupine/plugins/aboutdialog.py
@@ -74,10 +74,7 @@ def show_about_dialog() -> None:
 
     textwidget.config(state="normal")
     textutils.LinkManager(
-        textwidget,
-        r"\[(.+?)\]\((.*?)\)",
-        get_link_opener,
-        get_text=(lambda m: m.group(1)),
+        textwidget, r"\[(.+?)\]\((.*?)\)", get_link_opener, get_text=(lambda m: m.group(1))
     ).append_text(BORING_TEXT.strip() + "\n\n")
     textwidget.config(state="disabled")
 

--- a/porcupine/plugins/aboutdialog.py
+++ b/porcupine/plugins/aboutdialog.py
@@ -14,9 +14,6 @@ from typing import Callable
 from porcupine import __version__ as porcupine_version
 from porcupine import get_main_window, images, menubar, plugins, textutils, utils
 
-_install_path = Path(__file__).absolute().parent.parent.parent
-_plugin_path = Path(plugins.__path__[0])
-
 BORING_TEXT = f"""
 Porcupine is a simple but powerful and configurable text editor written in \
 Python using the notorious tkinter GUI library. It started as a \
@@ -36,17 +33,17 @@ Porcupine is available under the MIT license. It means that you can do \
 pretty much anything you want with it as long as you distribute the \
 LICENSE file with it. [Click here](https://github.com/Akuli/porcupine/blob/master/LICENSE) for details.
 
-Porcupine is installed to [{_install_path}]({_install_path}).
-You can install plugins to [{_plugin_path}]({_plugin_path}).
+Porcupine is installed to [{Path(__file__).absolute().parent.parent.parent}]().
+You can install plugins to [{plugins.__path__[0]}]().
 """
 
 
 def get_link_opener(match: re.Match[str]) -> Callable[[], object]:
-    url_or_path = match.group(2)
-    if url_or_path.startswith("https://"):
-        return lambda: webbrowser.open(url_or_path)
+    url = match.group(2)
+    if url:
+        return lambda: webbrowser.open(url)
 
-    path = Path(url_or_path)
+    path = Path(match.group(1))
     assert path.is_dir()
     if sys.platform == "win32":
         return lambda: os.startfile(path)
@@ -75,7 +72,7 @@ def show_about_dialog() -> None:
     textwidget.config(state="normal")
     textutils.LinkManager(
         textwidget,
-        r"\[(.+?)\]\((.+?)\)",
+        r"\[(.+?)\]\((.*?)\)",
         get_link_opener,
         get_text=(lambda m: m.group(1)),
     ).append_text(BORING_TEXT.strip() + "\n\n")

--- a/porcupine/plugins/aboutdialog.py
+++ b/porcupine/plugins/aboutdialog.py
@@ -45,9 +45,11 @@ def get_link_opener(match: re.Match[str]) -> Callable[[], object]:
 
     path = Path(match.group(1))
     assert path.is_dir()
-    if sys.platform == "win32":
+
+    # str() needed because mypy is awesome
+    if str(sys.platform) == "win32":
         return lambda: os.startfile(path)
-    if sys.platform == "darwin":
+    if str(sys.platform) == "darwin":
         return lambda: subprocess.Popen(["open", path])
     return lambda: subprocess.Popen(["xdg-open", path])
 

--- a/porcupine/plugins/aboutdialog.py
+++ b/porcupine/plugins/aboutdialog.py
@@ -14,29 +14,6 @@ from typing import Callable
 from porcupine import __version__ as porcupine_version
 from porcupine import get_main_window, images, menubar, plugins, textutils, utils
 
-BORING_TEXT = f"""
-Porcupine is a simple but powerful and configurable text editor written in \
-Python using the notorious tkinter GUI library. It started as a \
-proof-of-concept of a somewhat good editor written in tkinter, but nowadays \
-it's a tool I use at work every day.
-
-I'm [Akuli](https://github.com/Akuli), and I wrote most of Porcupine. See \
-[the contributor \
-page](https://github.com/Akuli/porcupine/graphs/contributors) for details.
-
-Links:
-\N{bullet} [Porcupine Wiki](https://github.com/Akuli/porcupine/wiki)
-\N{bullet} [Porcupine on GitHub](https://github.com/Akuli/porcupine)
-\N{bullet} [Plugin API documentation for Python programmers](https://akuli.github.io/porcupine/)
-
-Porcupine is available under the MIT license. It means that you can do \
-pretty much anything you want with it as long as you distribute the \
-LICENSE file with it. [Click here](https://github.com/Akuli/porcupine/blob/master/LICENSE) for details.
-
-Porcupine is installed to [{Path(__file__).absolute().parent.parent.parent}]().
-You can install plugins to [{plugins.__path__[0]}]().
-"""
-
 
 def get_link_opener(match: re.Match[str]) -> Callable[[], object]:
     url = match.group(2)
@@ -75,7 +52,30 @@ def show_about_dialog() -> None:
     textwidget.config(state="normal")
     textutils.LinkManager(
         textwidget, r"\[(.+?)\]\((.*?)\)", get_link_opener, get_text=(lambda m: m.group(1))
-    ).append_text(BORING_TEXT.strip() + "\n\n")
+    ).append_text(
+        f"""\
+Porcupine is a simple but powerful and configurable text editor written in \
+Python using the notorious tkinter GUI library. It started as a \
+proof-of-concept of a somewhat good editor written in tkinter, but nowadays \
+it's a tool I use at work every day.
+
+I'm [Akuli](https://github.com/Akuli), and I wrote most of Porcupine. See \
+[the contributor \
+page](https://github.com/Akuli/porcupine/graphs/contributors) for details.
+
+Links:
+\N{bullet} [Porcupine Wiki](https://github.com/Akuli/porcupine/wiki)
+\N{bullet} [Porcupine on GitHub](https://github.com/Akuli/porcupine)
+\N{bullet} [Plugin API documentation for Python programmers](https://akuli.github.io/porcupine/)
+
+Porcupine is available under the MIT license. It means that you can do \
+pretty much anything you want with it as long as you distribute the \
+LICENSE file with it. [Click here](https://github.com/Akuli/porcupine/blob/master/LICENSE) for details.
+
+Porcupine is installed to [{Path(__file__).absolute().parent.parent.parent}]().
+You can install plugins to [{plugins.__path__[0]}]().
+"""
+    )
     textwidget.config(state="disabled")
 
     if utils.is_bright(textwidget["bg"]):

--- a/porcupine/plugins/aboutdialog.py
+++ b/porcupine/plugins/aboutdialog.py
@@ -61,8 +61,8 @@ class AboutDialogContent(ttk.Frame):
         textutils.LinkManager(
             self._textwidget,
             r"\[(.+?)\]\((.+?)\)",
+            self._get_link_opener,
             get_text=(lambda m: m.group(1)),
-            get_click_callback=self._get_link_opener,
         ).append_text(BORING_TEXT.strip() + "\n\n")
         self._textwidget.config(state="disabled")
 

--- a/porcupine/plugins/run/no_terminal.py
+++ b/porcupine/plugins/run/no_terminal.py
@@ -37,10 +37,7 @@ class NoTerminalRunner:
 
         self._cwd: Path | None = None  # can't pass data to callbacks when adding link
         self._link_manager = textutils.LinkManager(
-            self.textwidget,
-            filename_regex,
-            get_text=(lambda m: m.group(0)),
-            get_click_callback=self._get_link_opener,
+            self.textwidget, filename_regex, self._get_link_opener
         )
         self.textwidget.tag_config("link", underline=True)
 

--- a/porcupine/plugins/run/no_terminal.py
+++ b/porcupine/plugins/run/no_terminal.py
@@ -27,7 +27,7 @@ filename_regex_parts = [
 filename_regex = "|".join(r"(?:" + part + r")" for part in filename_regex_parts)
 
 
-def open_file_with_line_number(self, path: Path, lineno: int) -> None:
+def open_file_with_line_number(path: Path, lineno: int) -> None:
     tab = get_tab_manager().open_file(path)
     if tab is not None:
         tab.textwidget.mark_set("insert", f"{lineno}.0")

--- a/porcupine/plugins/run/no_terminal.py
+++ b/porcupine/plugins/run/no_terminal.py
@@ -8,10 +8,11 @@ import re
 import subprocess
 import threading
 import tkinter
+from functools import partial
 from pathlib import Path
-from typing import Iterator
+from typing import Callable
 
-from porcupine import get_tab_manager, images, utils
+from porcupine import get_tab_manager, images, textutils, utils
 
 log = logging.getLogger(__name__)
 
@@ -26,21 +27,6 @@ filename_regex_parts = [
 filename_regex = "|".join(r"(?:" + part + r")" for part in filename_regex_parts)
 
 
-def parse_paths(cwd: Path, line: str) -> Iterator[tuple[str, Path, int] | str]:
-    previous_end = 0
-    for match in re.finditer(filename_regex, line):
-        filename, lineno = (value for value in match.groups() if value is not None)
-        path = cwd / filename  # doesn't use cwd if filename is absolute
-        if not path.is_file():
-            continue
-
-        yield line[previous_end : match.start()]
-        yield (match.group(0), path, int(lineno))
-        previous_end = match.end()
-
-    yield line[previous_end:]
-
-
 class NoTerminalRunner:
     def __init__(self, master: tkinter.Misc) -> None:
         # TODO: better coloring that follows the pygments theme
@@ -48,37 +34,40 @@ class NoTerminalRunner:
         self.textwidget.tag_config("info", foreground="blue")
         self.textwidget.tag_config("output")  # use default colors
         self.textwidget.tag_config("error", foreground="red")
-        self.textwidget.tag_config("link", underline=True)
-        self.textwidget.tag_bind("link", "<Enter>", self._enter_link)
-        self.textwidget.tag_bind("link", "<Leave>", self._leave_link)
-        self.textwidget.tag_bind("link", "<Button-1>", self._open_link)
 
-        self._output_queue: queue.Queue[tuple[Path, str, str]] = queue.Queue()
+        self._cwd: Path | None = None  # can't pass data to callbacks when adding link
+        self._link_manager = textutils.LinkManager(
+            self.textwidget,
+            filename_regex,
+            get_text=(lambda m: m.group(0)),
+            get_click_callback=self._get_link_opener,
+        )
+        self.textwidget.tag_config("link", underline=True)
+
+        self._output_queue: queue.Queue[tuple[str, str]] = queue.Queue()
         self._running_process: subprocess.Popen[bytes] | None = None
         self._queue_handler()
 
-        self._links: dict[str, tuple[Path, int]] = {}
+    def _get_link_opener(self, match: re.Match[str]) -> Callable[[], None] | None:
+        assert self._cwd is not None
 
-    # TODO: much links code copy/pasted from aboutdialog plugin
-    def _enter_link(self, junk_event: tkinter.Event[tkinter.Misc]) -> None:
-        self.textwidget.config(cursor="hand2")
+        filename, lineno = (value for value in match.groups() if value is not None)
+        path = self._cwd / filename  # doesn't use cwd if filename is absolute
+        if not path.is_file():
+            return None
+        return partial(self._open_link, path, int(lineno))
 
-    def _leave_link(self, junk_event: tkinter.Event[tkinter.Misc]) -> None:
-        self.textwidget.config(cursor="")
-
-    def _open_link(self, junk_event: tkinter.Event[tkinter.Misc]) -> None:
-        for tag in self.textwidget.tag_names("current"):
-            if tag.startswith("link-"):
-                path, lineno = self._links[tag]
-                tab = get_tab_manager().open_file(path)
-                if tab is not None:
-                    tab.textwidget.mark_set("insert", f"{lineno}.0")
-                    tab.textwidget.see("insert")
-                    tab.textwidget.tag_remove("sel", "1.0", "end")
-                    tab.textwidget.tag_add("sel", "insert", "insert lineend")
-                break
+    def _open_link(self, path: Path, lineno: int) -> None:
+        tab = get_tab_manager().open_file(path)
+        if tab is not None:
+            tab.textwidget.mark_set("insert", f"{lineno}.0")
+            tab.textwidget.see("insert")
+            tab.textwidget.tag_remove("sel", "1.0", "end")
+            tab.textwidget.tag_add("sel", "insert", "insert lineend")
 
     def run_command(self, cwd: Path, command: str) -> None:
+        self._cwd = cwd
+
         # this is a daemon thread because i don't care what the fuck
         # happens to it when python exits
         threading.Thread(target=self._runner_thread, args=[cwd, command], daemon=True).start()
@@ -90,7 +79,7 @@ class NoTerminalRunner:
             if process is not None and self._running_process is not process:
                 # another _run_command() is already running
                 return
-            self._output_queue.put((cwd,) + msg)
+            self._output_queue.put(msg)
 
         emit_message(("clear", ""))
         emit_message(("info", command + "\n"))
@@ -127,7 +116,7 @@ class NoTerminalRunner:
             emit_message(("error", f"The process failed with status {process.returncode}."))
 
     def _queue_handler(self) -> None:
-        messages: list[tuple[Path, str, str]] = []
+        messages: list[tuple[str, str]] = []
         while True:
             try:
                 messages.append(self._output_queue.get(block=False))
@@ -136,20 +125,13 @@ class NoTerminalRunner:
 
         if messages:
             self.textwidget.config(state="normal")
-            for cwd, tag, output_line in messages:
+            for tag, output_line in messages:
                 if tag == "clear":
                     assert not output_line
+                    self._link_manager.delete_all_links()
                     self.textwidget.delete("1.0", "end")
-                    self._links.clear()
                 else:
-                    for part in parse_paths(cwd, output_line):
-                        if isinstance(part, str):
-                            self.textwidget.insert("end", part, [tag])
-                        else:
-                            text, path, lineno = part
-                            link_specific_tag = f"link-{len(self._links)}"
-                            self._links[link_specific_tag] = (path, lineno)
-                            self.textwidget.insert("end", text, [tag, "link", link_specific_tag])
+                    self._link_manager.append_text(output_line, [tag])
             self.textwidget.config(state="disabled")
 
         self.textwidget.after(100, self._queue_handler)

--- a/porcupine/plugins/run/no_terminal.py
+++ b/porcupine/plugins/run/no_terminal.py
@@ -27,6 +27,15 @@ filename_regex_parts = [
 filename_regex = "|".join(r"(?:" + part + r")" for part in filename_regex_parts)
 
 
+def open_file_with_line_number(self, path: Path, lineno: int) -> None:
+    tab = get_tab_manager().open_file(path)
+    if tab is not None:
+        tab.textwidget.mark_set("insert", f"{lineno}.0")
+        tab.textwidget.see("insert")
+        tab.textwidget.tag_remove("sel", "1.0", "end")
+        tab.textwidget.tag_add("sel", "insert", "insert lineend")
+
+
 class NoTerminalRunner:
     def __init__(self, master: tkinter.Misc) -> None:
         # TODO: better coloring that follows the pygments theme
@@ -52,15 +61,7 @@ class NoTerminalRunner:
         path = self._cwd / filename  # doesn't use cwd if filename is absolute
         if not path.is_file():
             return None
-        return partial(self._open_link, path, int(lineno))
-
-    def _open_link(self, path: Path, lineno: int) -> None:
-        tab = get_tab_manager().open_file(path)
-        if tab is not None:
-            tab.textwidget.mark_set("insert", f"{lineno}.0")
-            tab.textwidget.see("insert")
-            tab.textwidget.tag_remove("sel", "1.0", "end")
-            tab.textwidget.tag_add("sel", "insert", "insert lineend")
+        return partial(open_file_with_line_number, path, int(lineno))
 
     def run_command(self, cwd: Path, command: str) -> None:
         self._cwd = cwd

--- a/porcupine/textutils.py
+++ b/porcupine/textutils.py
@@ -551,8 +551,9 @@ class LinkManager:
         self,
         textwidget: tkinter.Text,
         link_regex: str,
-        get_text: Callable[[re.Match[str]], str],
         get_click_callback: Callable[[re.Match[str]], Callable[[], object] | None],
+        *,
+        get_text: Callable[[re.Match[str]], str] = (lambda m: m.group(0)),
     ) -> None:
         self._textwidget = textwidget
         self._link_regex = link_regex

--- a/tests/test_about_dialog.py
+++ b/tests/test_about_dialog.py
@@ -17,6 +17,7 @@ def test_it_doesnt_crash(monkeypatch):
 
     monkeypatch.setattr("tkinter.Toplevel.wait_window", fake_wait_window)
 
+    get_main_window().update()
     get_main_window().event_generate("<<Menubar:Help/About Porcupine>>")
     assert called == 1
 

--- a/tests/test_about_dialog.py
+++ b/tests/test_about_dialog.py
@@ -3,6 +3,7 @@
 
 from urllib.request import url2pathname
 
+from porcupine import get_main_window
 from porcupine.plugins import aboutdialog
 
 

--- a/tests/test_about_dialog.py
+++ b/tests/test_about_dialog.py
@@ -3,7 +3,6 @@
 
 from urllib.request import url2pathname
 
-from porcupine import get_main_window
 from porcupine.plugins import aboutdialog
 
 
@@ -16,9 +15,7 @@ def test_it_doesnt_crash(monkeypatch):
         self.destroy()  # can't do this with mock objects
 
     monkeypatch.setattr("tkinter.Toplevel.wait_window", fake_wait_window)
-
-    get_main_window().update()
-    get_main_window().event_generate("<<Menubar:Help/About Porcupine>>")
+    aboutdialog.show_about_dialog()
     assert called == 1
 
 

--- a/tests/test_about_dialog.py
+++ b/tests/test_about_dialog.py
@@ -6,7 +6,7 @@ from urllib.request import url2pathname
 from porcupine.plugins import aboutdialog
 
 
-def test_it_doesnt_crash(monkeypatch):
+def test_it_doesnt_crash(monkeypatch, monkeypatch_dirs):
     called = 0
 
     def fake_wait_window(self):

--- a/tests/test_about_dialog.py
+++ b/tests/test_about_dialog.py
@@ -15,7 +15,7 @@ def test_it_doesnt_crash(monkeypatch, monkeypatch_dirs):
         self.destroy()  # can't do this with mock objects
 
     monkeypatch.setattr("tkinter.Toplevel.wait_window", fake_wait_window)
-    aboutdialog.show_about_dialog()
+    get_main_window().event_generate("<<Menubar:Help/About Porcupine>>")
     assert called == 1
 
 

--- a/tests/test_about_dialog.py
+++ b/tests/test_about_dialog.py
@@ -1,8 +1,6 @@
 # not much can be done here, other than running the dialog and trying to get a
 # good coverage
 
-import tkinter
-import types
 from urllib.request import url2pathname
 
 from porcupine import get_main_window
@@ -10,32 +8,28 @@ from porcupine.plugins import aboutdialog
 
 
 def test_it_doesnt_crash(monkeypatch):
-    # the dialog calls .wait_window(), but that doesn't terminate until the
-    # user closes the window... so we'll make the window close itself
     called = 0
 
     def fake_wait_window(self):
         nonlocal called
         called += 1
-        self.destroy()
+        self.destroy()  # can't do this with mock objects
 
-    monkeypatch.setattr(tkinter.Toplevel, "wait_window", fake_wait_window)
+    monkeypatch.setattr("tkinter.Toplevel.wait_window", fake_wait_window)
 
     get_main_window().event_generate("<<Menubar:Help/About Porcupine>>")
     assert called == 1
 
 
-def test_show_huge_logo(monkeypatch):
-    opened = []
-    fake_webbrowser = types.SimpleNamespace(open=opened.append)
-    monkeypatch.setattr(aboutdialog, "webbrowser", fake_webbrowser)
+def test_show_huge_logo(mocker):
+    mock = mocker.patch("porcupine.plugins.aboutdialog.webbrowser").open
     aboutdialog.show_huge_logo()
+    mock.assert_called_once()
 
-    [url] = opened
+    [url] = mock.call_args[0]
     assert url.startswith("file://")
     path = url2pathname(url[len("file://") :])
 
-    # make sure it's a gif
     assert path.endswith(".gif")
     with open(path, "rb") as file:
-        assert file.read(3) == b"GIF"  # every gif file starts with this
+        assert file.read(3) == b"GIF"

--- a/tests/test_run_plugin.py
+++ b/tests/test_run_plugin.py
@@ -94,11 +94,11 @@ def test_python_unbuffered(filetab, tmp_path):
         """
 import time
 print("This should show up immediately")
-time.sleep(2)
+time.sleep(5)
 """
     )
     no_terminal.run_command(f"{utils.quote(sys.executable)} sleeper.py", tmp_path)
-    tkinter_sleep(1)
+    tkinter_sleep(3)
     assert "This should show up immediately" in get_output(filetab)
 
 

--- a/tests/test_run_plugin.py
+++ b/tests/test_run_plugin.py
@@ -81,7 +81,7 @@ def test_python_error_message(filetab, tabmanager, tmp_path):
     # click the last link
     textwidget = get_output_widget(filetab)
     textwidget.mark_set("current", "link.last - 1 char")
-    no_terminal._no_terminal_runners[str(filetab)]._open_link(None)
+    no_terminal._no_terminal_runners[str(filetab)]._link_manager._open_link(None)
 
     selected_tab = tabmanager.select()
     assert selected_tab != filetab


### PR DESCRIPTION
aboutdialog and run plugins had very similar code for creating links. Move it into `utils` and change it so that the same code can be used for both.