### PR TITLE
run plugin: windows link clicking fix

### DIFF
--- a/porcupine/plugins/run/no_terminal.py
+++ b/porcupine/plugins/run/no_terminal.py
@@ -35,7 +35,6 @@ def open_file_with_line_number(path: Path, lineno: int) -> None:
         tab.textwidget.see("insert")
         tab.textwidget.tag_remove("sel", "1.0", "end")
         tab.textwidget.tag_add("sel", "insert", "insert lineend")
-        tab.textwidget.focus()
 
 
 class NoTerminalRunner:

--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -146,6 +146,7 @@ class TabManager(ttk.Notebook):
         if existing_tab != tab:
             # tab is destroyed
             assert isinstance(existing_tab, FileTab)
+            existing_tab.textwidget.focus()
             return existing_tab
 
         if not tab.reload(undoable=False):


### PR DESCRIPTION
This makes clicking a file name link into the currently opened file actually work.