### PR TITLE
pyls: delete pycodestyle

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Pygments==2.7.4
 toposort>=1.5
 colorama>=0.2.5
 sansio-lsp-client>=0.10.0,<0.11.0
-python-language-server[rope,pyflakes,pycodestyle]>=0.36.2,<1.0.0
+python-language-server[rope,pyflakes]>=0.36.2,<1.0.0
 black>=21.5b2
 # typing.Literal is new in python 3.8
 typing_extensions


### PR DESCRIPTION
Fixes the real underlying problem in #847: there's no longer style warnings for python code, which is great as most python projects don't use a fully pycodestyle-compatible style.