### PR TITLE
run plugin: fix nooby regex bugs

### DIFF
--- a/porcupine/plugins/run/no_terminal.py
+++ b/porcupine/plugins/run/no_terminal.py
@@ -35,9 +35,9 @@ log = logging.getLogger(__name__)
 filename_regex_parts = [
     # c compiler output
     # playground.c:4:9: warning: ...
-    r"\b([^:]+):([0-9]+)(?=:)",
+    r"\b([^\n:]+):([0-9]+)(?=:)",
     # python error
-    r'File "([^"]+)", line ([0-9]+)',
+    r'File "([^\n"]+)", line ([0-9]+)',
 ]
 filename_regex = "|".join(r"(?:" + part + r")" for part in filename_regex_parts)
 

--- a/porcupine/textutils.py
+++ b/porcupine/textutils.py
@@ -576,7 +576,8 @@ class LinkManager:
 
     # If you add text in parts, make sure that each link is within one part
     def add_links(self, start: str, end: str) -> None:
-        for match in re.finditer(self._link_regex, self._textwidget.get(start, end)):
+        text = self._textwidget.get(start, end)
+        for match in re.finditer(self._link_regex, text, flags=re.MULTILINE):
             callback = self._get_click_callback(match)
             if callback is None:
                 continue


### PR DESCRIPTION
Fixes corner cases in displaying links programs that output many lines of text in a single write.