### PR TITLE
run plugin: detect filenames from pytest output

### DIFF
--- a/porcupine/plugins/run/no_terminal.py
+++ b/porcupine/plugins/run/no_terminal.py
@@ -36,7 +36,7 @@ filename_regex_parts = [
     # c compiler output, also many other tools
     # TODO: support spaces in file names?
     # playground.c:4:9: warning: ...
-    r"([^\n\s:]+):([0-9]+)(?=:)",
+    r"([^\n\s:]+):([0-9]+)",
     # python error
     r'File "([^\n"]+)", line ([0-9]+)',
 ]

--- a/tests/test_run_plugin.py
+++ b/tests/test_run_plugin.py
@@ -139,6 +139,13 @@ def test_mypy_error_message(filetab, tabmanager, tmp_path, wait_until):
     assert click_last_link() == "print(1 + 'lol')"
 
 
+def test_pytest_error_message(tabmanager, tmp_path, wait_until):
+    (tmp_path / "tests.py").write_text("def test_foo(asdf): pass")
+    no_terminal.run_command(f"{utils.quote(sys.executable)} -m pytest tests.py", tmp_path)
+    wait_until(lambda: "The process failed with status 1." in get_output())
+    assert click_last_link() == "def test_foo(asdf): pass"
+
+
 def test_bindcheck_message(filetab, tabmanager, tmp_path, wait_until):
     filetab.textwidget.insert("end", "asdf.bind('<Foo>', print)")
     (tmp_path / "foo").mkdir()


### PR DESCRIPTION
Previously the regex matched `foo.py:2:`. Now it matches `foo.py:2`, without requiring the trailing `:`.