### PR TITLE
remove explicit geometry from settings dialog

### DIFF
--- a/porcupine/settings.py
+++ b/porcupine/settings.py
@@ -466,7 +466,6 @@ def _create_dialog_content() -> ttk.Frame:
     dialog.title("Porcupine Settings")
     dialog.protocol("WM_DELETE_WINDOW", dialog.withdraw)
     dialog.bind("<Escape>", (lambda event: dialog.withdraw()), add=True)
-    dialog.geometry("600x350")
 
     def confirm_and_reset_all() -> None:
         if messagebox.askyesno(


### PR DESCRIPTION
Which made the bottom buttons invisible for with some themes.
![image](https://user-images.githubusercontent.com/77941087/137978801-24570cf1-3c1e-4ae0-b952-478bb759caac.png)