### PR TITLE
run plugin: print CRLF correctly on any platform

### DIFF
--- a/porcupine/plugins/run/no_terminal.py
+++ b/porcupine/plugins/run/no_terminal.py
@@ -103,7 +103,7 @@ class Executor:
             if not bytez:
                 break
             text = bytez.decode(locale.getpreferredencoding(), errors="replace")
-            self._queue.put(("output", utils.tkinter_safe_string(text).replace(os.linesep, "\n")))
+            self._queue.put(("output", utils.tkinter_safe_string(text).replace("\r\n", "\n")))
 
         status = self._shell_process.wait()
         if status == 0:

--- a/tests/test_run_plugin.py
+++ b/tests/test_run_plugin.py
@@ -232,6 +232,12 @@ time.sleep(10)
     assert end - start < 8
 
 
+def test_crlf_on_any_platform(tmp_path, wait_until):
+    (tmp_path / "crlf.py").write_text(r"import sys; sys.stdout.buffer.write(b'foo\r\nbar')")
+    no_terminal.run_command(f"{utils.quote(sys.executable)} crlf.py", tmp_path)
+    wait_until(lambda: "foo\nbar" in get_output())
+
+
 def test_changing_current_file(filetab, tmp_path, wait_until):
     filetab.textwidget.insert("end", 'with open("foo.py", "w") as f: f.write("lol")')
     filetab.save_as(tmp_path / "foo.py")


### PR DESCRIPTION
Fixes #979