### PR TITLE
"Copy full path to clipboard" right click option

### DIFF
--- a/porcupine/plugins/filemanager.py
+++ b/porcupine/plugins/filemanager.py
@@ -389,7 +389,7 @@ commands = [
     Command("Delete", "<<FileManager:Delete>>", is_NOT_project_root, delete),
     Command("Open in file manager", None, (lambda p: p.is_dir()), open_in_file_manager),
     Command("Open in terminal", None, (lambda p: p.is_dir()), open_in_terminal),
-    Command("Copy full path to clipboard", None, (lambda p: p.is_dir()), copy_full_path_to_clipboard),
+    Command("Copy full path to clipboard", None, (lambda p: True), copy_full_path_to_clipboard),
 ]
 
 

--- a/porcupine/plugins/filemanager.py
+++ b/porcupine/plugins/filemanager.py
@@ -316,17 +316,6 @@ def open_in_file_manager(path: Path) -> None:
     subprocess.Popen([opener_command, str(path)])
 
 
-def open_in_terminal(path: Path) -> None:
-    # Using pushd for windows to change drive aswell navigate to directory
-    windowingsystem = get_main_window().tk.call("tk", "windowingsystem")
-    if windowingsystem == "win32":
-        command = "pushd"
-    else:
-        command = "cd"
-
-    subprocess.Popen(f"start /wait {command} {path}", shell=True)
-
-
 def copy_full_path_to_clipboard(path: Path) -> None:
     main_window = get_main_window()
     main_window.clipboard_clear()
@@ -388,7 +377,6 @@ commands = [
     Command(f"Move to {trash_name}", "<<FileManager:Trash>>", is_NOT_project_root, trash),
     Command("Delete", "<<FileManager:Delete>>", is_NOT_project_root, delete),
     Command("Open in file manager", None, (lambda p: p.is_dir()), open_in_file_manager),
-    Command("Open in terminal", None, (lambda p: p.is_dir()), open_in_terminal),
     Command("Copy full path to clipboard", None, (lambda p: True), copy_full_path_to_clipboard),
 ]
 

--- a/porcupine/plugins/filemanager.py
+++ b/porcupine/plugins/filemanager.py
@@ -330,7 +330,7 @@ def get_selected_path(tree: DirectoryTree) -> Path | None:
         return None
     return get_path(item)
 
-    
+
 @dataclasses.dataclass
 class Command:
     name: str

--- a/porcupine/plugins/filemanager.py
+++ b/porcupine/plugins/filemanager.py
@@ -316,6 +316,12 @@ def open_in_file_manager(path: Path) -> None:
     subprocess.Popen([opener_command, str(path)])
 
 
+def copy_full_path_to_clipboard(path: Path) -> None:
+    main_window = get_main_window()
+    main_window.clipboard_clear()
+    main_window.clipboard_append(str(path))
+
+
 def get_selected_path(tree: DirectoryTree) -> Path | None:
     try:
         [item] = tree.selection()
@@ -371,6 +377,7 @@ commands = [
     Command(f"Move to {trash_name}", "<<FileManager:Trash>>", is_NOT_project_root, trash),
     Command("Delete", "<<FileManager:Delete>>", is_NOT_project_root, delete),
     Command("Open in file manager", None, (lambda p: p.is_dir()), open_in_file_manager),
+    Command("Copy full path to clipboard", None, (lambda p: p.is_dir()), copy_full_path_to_clipboard),
 ]
 
 

--- a/porcupine/plugins/filemanager.py
+++ b/porcupine/plugins/filemanager.py
@@ -316,6 +316,17 @@ def open_in_file_manager(path: Path) -> None:
     subprocess.Popen([opener_command, str(path)])
 
 
+def open_in_terminal(path: Path) -> None:
+    # Using pushd for windows to change drive aswell navigate to directory
+    windowingsystem = get_main_window().tk.call("tk", "windowingsystem")
+    if windowingsystem == "win32":
+        command = "pushd"
+    else:
+        command = "cd"
+
+    subprocess.Popen(f"start /wait {command} {path}", shell=True)
+
+
 def copy_full_path_to_clipboard(path: Path) -> None:
     main_window = get_main_window()
     main_window.clipboard_clear()
@@ -330,7 +341,7 @@ def get_selected_path(tree: DirectoryTree) -> Path | None:
         return None
     return get_path(item)
 
-
+    
 @dataclasses.dataclass
 class Command:
     name: str
@@ -377,6 +388,7 @@ commands = [
     Command(f"Move to {trash_name}", "<<FileManager:Trash>>", is_NOT_project_root, trash),
     Command("Delete", "<<FileManager:Delete>>", is_NOT_project_root, delete),
     Command("Open in file manager", None, (lambda p: p.is_dir()), open_in_file_manager),
+    Command("Open in terminal", None, (lambda p: p.is_dir()), open_in_terminal),
     Command("Copy full path to clipboard", None, (lambda p: p.is_dir()), copy_full_path_to_clipboard),
 ]
 


### PR DESCRIPTION
Resolve part of #1042

Since this is my first time contributing to this repo, after studying the code base & docs here is what I came up with.

Added the following features:
- "Copy full path to clipboard": made use of tkinter's clipboard functions, also used the is_dir() validation which was being used previously with other options.
- "Open in terminal": used the subprocess module to open a new terminal with the directory that was chosen.

I coded and tested this on my windows 11 machine.