### PR TITLE
filetypes plugin: make sure default_filetype setting always exists

### DIFF
--- a/porcupine/plugins/filetypes.py
+++ b/porcupine/plugins/filetypes.py
@@ -232,10 +232,11 @@ def setup_argument_parser(parser: argparse.ArgumentParser) -> None:
 
 
 def setup() -> None:
+    settings.add_option("default_filetype", "Python")
+
     # load_filetypes() got already called in setup_argument_parser()
     get_tab_manager().add_filetab_callback(on_new_filetab)
 
-    settings.add_option("default_filetype", "Python")
     settings.add_combobox(
         "default_filetype",
         "Default filetype for new files:",


### PR DESCRIPTION
Fixes an error that I no longer remember how to reproduce. But even if there was no bug, it would make sense to initialize the global settings before doing anything else.