### PR TITLE
Fix resolution on Windows 10

### DIFF
--- a/porcupine/_state.py
+++ b/porcupine/_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 import os
+import sys
 import tkinter
 import types
 from typing import Any, Type
@@ -12,7 +13,7 @@ import platform
 from porcupine import images, tabs, utils
 
 # Windows resolution
-if platform.system() == "Windows":
+if sys.platform == "win32":
     from ctypes import windll
 
     windows_version = platform.release()

--- a/porcupine/_state.py
+++ b/porcupine/_state.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 import dataclasses
 import logging
 import os
+import platform
 import sys
 import tkinter
 import types
 from typing import Any, Type
-import platform
 
 from porcupine import images, tabs, utils
 

--- a/porcupine/_state.py
+++ b/porcupine/_state.py
@@ -17,9 +17,10 @@ if sys.platform == "win32":
     from ctypes import windll
 
     windows_version = platform.release()
-    if windows_version == "10" or windows_version == "11":
+    try:
         windll.shcore.SetProcessDpiAwareness(1)
-    elif windows_version == "7" or windows_version == "Vista":
+    except (AttributeError, OSError):
+        # Windows 7 or older
         windll.user32.SetProcessDPIAware()
 
 log = logging.getLogger(__name__)

--- a/porcupine/_state.py
+++ b/porcupine/_state.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 import dataclasses
 import logging
 import os
+import sys
 import tkinter
 import types
 from typing import Any, Type
-from sys import platform
 
 from porcupine import images, tabs, utils
 
-if platform == "win32":
+if sys.platform == "win32":
     from ctypes import windll
 
     windll.shcore.SetProcessDpiAwareness(1)

--- a/porcupine/_state.py
+++ b/porcupine/_state.py
@@ -4,20 +4,22 @@ from __future__ import annotations
 import dataclasses
 import logging
 import os
-import sys
 import tkinter
 import types
 from typing import Any, Type
+import platform
 
 from porcupine import images, tabs, utils
 
-if sys.platform == "win32":
+# Windows resolution
+if platform.system() == "Windows":
     from ctypes import windll
 
-    try:
+    windows_version = platform.release()
+    if windows_version == "10" or windows_version == "11":
         windll.shcore.SetProcessDpiAwareness(1)
-    except FileNotFoundError:  # windows 7
-        pass
+    elif windows_version == "7" or windows_version == "Vista":
+        windll.user32.SetProcessDPIAware()
 
 log = logging.getLogger(__name__)
 
@@ -128,7 +130,6 @@ def quit() -> None:
             return
         # the tabs must not be closed here, otherwise some of them
         # are closed if not all tabs can be closed
-
     get_main_window().event_generate("<<PorcupineQuit>>")  # TODO: still needed?
     for tab in get_tab_manager().tabs():
         get_tab_manager().close_tab(tab)

--- a/porcupine/_state.py
+++ b/porcupine/_state.py
@@ -6,13 +6,18 @@ import logging
 import os
 import tkinter
 import types
-from ctypes import windll
 from typing import Any, Type
 
 from porcupine import images, tabs, utils
 
+try:
+    from ctypes import windll
+
+    windll.shcore.SetProcessDpiAwareness(1)
+except ImportError:
+    pass  # Therefore, not on Windows.
+
 log = logging.getLogger(__name__)
-windll.shcore.SetProcessDpiAwareness(1)
 
 
 @dataclasses.dataclass

--- a/porcupine/_state.py
+++ b/porcupine/_state.py
@@ -7,15 +7,14 @@ import os
 import tkinter
 import types
 from typing import Any, Type
+from sys import platform
 
 from porcupine import images, tabs, utils
 
-try:
+if platform == "win32":
     from ctypes import windll
 
     windll.shcore.SetProcessDpiAwareness(1)
-except ImportError:
-    pass  # Therefore, not on Windows.
 
 log = logging.getLogger(__name__)
 

--- a/porcupine/_state.py
+++ b/porcupine/_state.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import dataclasses
 import logging
 import os
-import platform
 import sys
 import tkinter
 import types
@@ -16,7 +15,6 @@ from porcupine import images, tabs, utils
 if sys.platform == "win32":
     from ctypes import windll
 
-    windows_version = platform.release()
     try:
         windll.shcore.SetProcessDpiAwareness(1)
     except (AttributeError, OSError):

--- a/porcupine/_state.py
+++ b/porcupine/_state.py
@@ -6,11 +6,13 @@ import logging
 import os
 import tkinter
 import types
+from ctypes import windll
 from typing import Any, Type
 
 from porcupine import images, tabs, utils
 
 log = logging.getLogger(__name__)
+windll.shcore.SetProcessDpiAwareness(1)
 
 
 @dataclasses.dataclass

--- a/porcupine/_state.py
+++ b/porcupine/_state.py
@@ -14,7 +14,10 @@ from porcupine import images, tabs, utils
 if sys.platform == "win32":
     from ctypes import windll
 
-    windll.shcore.SetProcessDpiAwareness(1)
+    try:
+        windll.shcore.SetProcessDpiAwareness(1)
+    except FileNotFoundError:  # windows 7
+        pass
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes #24 

Fixed the resolution on Windows 10 by using `ctypes.windll.shcore.SetProcessDpiAwareness(1)`.

Upon running, 5 tests failed. I'm not sure if this is induced by a problem on my end (and thus has nothing to do with the PR) or not. But it showed a higher resolution on execution on my Windows 10 machine. 
![image](https://user-images.githubusercontent.com/66365570/168420671-a876594d-75bf-4acd-a288-4085e4d27ed2.png)
