### PR TITLE
Fix annoying "Do you want to close" behavior

### DIFF
--- a/porcupine/_state.py
+++ b/porcupine/_state.py
@@ -126,7 +126,7 @@ def quit() -> None:
     destroyed.
     """
     get_main_window().event_generate("<<PorcupineQuit>>")  # TODO: still needed?
-    
+
     for tab in reversed(get_tab_manager().tabs()):
         if not tab.can_be_closed():
             return

--- a/porcupine/_state.py
+++ b/porcupine/_state.py
@@ -125,12 +125,11 @@ def quit() -> None:
     with :meth:`~porcupine.tabs.TabManager.close_tab` and widgets are
     destroyed.
     """
-    for tab in get_tab_manager().tabs():
+    get_main_window().event_generate("<<PorcupineQuit>>")  # TODO: still needed?
+    
+    for tab in reversed(get_tab_manager().tabs()):
         if not tab.can_be_closed():
             return
-        # the tabs must not be closed here, otherwise some of them
-        # are closed if not all tabs can be closed
-    get_main_window().event_generate("<<PorcupineQuit>>")  # TODO: still needed?
-    for tab in get_tab_manager().tabs():
         get_tab_manager().close_tab(tab)
+
     get_main_window().destroy()

--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -838,6 +838,8 @@ class FileTab(Tab):
             msg = "Do you want to save your changes?"
         else:
             msg = f"Do you want to save your changes to {self.path.name}?"
+        
+        self.master.select(self)
         answer = messagebox.askyesnocancel("Close file", msg)
         if answer is None:
             # cancel

--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -838,7 +838,7 @@ class FileTab(Tab):
             msg = "Do you want to save your changes?"
         else:
             msg = f"Do you want to save your changes to {self.path.name}?"
-        
+
         self.master.select(self)
         answer = messagebox.askyesnocancel("Close file", msg)
         if answer is None:


### PR DESCRIPTION
Fixes #605

Today I got annoyed by this behavior, so trying to fix it.
However, placing the `event_generate` before the `can_be_closed` stuff breaks the restart plugin. It doesn't know if the tab was saved or not. And it doesn't necessarily quit after the event, so it's dumb this way. Crap! 😕