### PR TITLE
Let user decide what to do with open tabs when closing Porcupine

### DIFF
--- a/docs/porcupine.rst
+++ b/docs/porcupine.rst
@@ -18,6 +18,7 @@ I recommend reading it first. Then you'll have a much better idea about what
 .. autofunction:: get_main_window
 .. autofunction:: get_tab_manager
 .. autofunction:: get_parsed_args
+.. autofunction:: add_close_callback
 .. autofunction:: quit
 
 

--- a/docs/porcupine.rst
+++ b/docs/porcupine.rst
@@ -18,7 +18,7 @@ I recommend reading it first. Then you'll have a much better idea about what
 .. autofunction:: get_main_window
 .. autofunction:: get_tab_manager
 .. autofunction:: get_parsed_args
-.. autofunction:: add_close_callback
+.. autofunction:: add_quit_callback
 .. autofunction:: quit
 
 

--- a/porcupine/__init__.py
+++ b/porcupine/__init__.py
@@ -29,8 +29,9 @@ from porcupine import _state
 # TODO: document get_*_panedwindow
 get_main_window = _state.get_main_window
 get_parsed_args = _state.get_parsed_args
-get_horizontal_panedwindow = _state.get_horizontal_panedwindow
-get_vertical_panedwindow = _state.get_vertical_panedwindow
+get_horizontal_panedwindow = _state.get_horizontal_panedwindow  # TODO: document this
+get_vertical_panedwindow = _state.get_vertical_panedwindow  # TODO: document this
 get_tab_manager = _state.get_tab_manager
 filedialog_kwargs = _state.filedialog_kwargs
+add_quit_callback = _state.add_quit_callback
 quit = _state.quit

--- a/porcupine/__init__.py
+++ b/porcupine/__init__.py
@@ -26,7 +26,6 @@ else:
 # Must be after creating dirs
 from porcupine import _state
 
-# TODO: document get_*_panedwindow
 get_main_window = _state.get_main_window
 get_parsed_args = _state.get_parsed_args
 get_horizontal_panedwindow = _state.get_horizontal_panedwindow  # TODO: document this

--- a/porcupine/_state.py
+++ b/porcupine/_state.py
@@ -30,7 +30,7 @@ class _State:
     horizontal_panedwindow: utils.PanedWindow
     vertical_panedwindow: utils.PanedWindow
     tab_manager: tabs.TabManager
-    close_callbacks: list[Callable[[], bool]]
+    quit_callbacks: list[Callable[[], bool]]
     parsed_args: Any  # not None
 
 
@@ -80,7 +80,7 @@ def init(args: Any) -> None:
         horizontal_panedwindow=horizontal_pw,
         vertical_panedwindow=vertical_pw,
         tab_manager=tab_manager,
-        close_callbacks=[],
+        quit_callbacks=[],
         parsed_args=args,
     )
     log.debug("init() done")
@@ -124,7 +124,7 @@ def add_quit_callback(callback: Callable[[], bool]) -> None:
     or ``False`` to prevent Porcupine from closing. This is useful for
     asking the user whether they really want to quit.
     """
-    _get_state().close_callbacks.append(callback)
+    _get_state().quit_callbacks.append(callback)
 
 
 def quit() -> None:
@@ -137,7 +137,7 @@ def quit() -> None:
     :meth:`~porcupine.tabs.TabManager.close_tab` and all widgets are
     destroyed.
     """
-    for callback in _get_state().close_callbacks:
+    for callback in _get_state().quit_callbacks:
         if not callback():
             return
 

--- a/porcupine/_state.py
+++ b/porcupine/_state.py
@@ -132,7 +132,7 @@ def quit() -> None:
     Calling this function is equivalent to clicking the X button in the
     corner of the main window.
 
-    First, close callbacks are ran (see :func:`add_quit_callback`).
+    First, quit callbacks are ran (see :func:`add_quit_callback`).
     If they all returned True, all tabs are closed by calling
     :meth:`~porcupine.tabs.TabManager.close_tab` and all widgets are
     destroyed.

--- a/porcupine/plugins/geometry.py
+++ b/porcupine/plugins/geometry.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 
 import re
-import tkinter
 
-from porcupine import get_main_window
+from porcupine import add_quit_callback, get_main_window
 from porcupine.settings import global_settings
 
 
@@ -23,14 +22,14 @@ def geometry_is_within_screen(geometry: str) -> bool:
     )
 
 
-def save_geometry(event: tkinter.Event[tkinter.Misc]) -> None:
-    assert isinstance(event.widget, (tkinter.Tk, tkinter.Toplevel))
-    global_settings.set("default_geometry", event.widget.geometry())
+def save_geometry() -> bool:
+    global_settings.set("default_geometry", get_main_window().geometry())
+    return True
 
 
 def setup() -> None:
     global_settings.add_option("default_geometry", "650x600")
-    get_main_window().bind("<<PorcupineQuit>>", save_geometry, add=True)
+    add_quit_callback(save_geometry)
 
     geometry = global_settings.get("default_geometry", str)
     if not geometry_is_within_screen(geometry):

--- a/porcupine/plugins/restart.py
+++ b/porcupine/plugins/restart.py
@@ -3,7 +3,7 @@ import logging
 import pickle
 from pathlib import Path
 
-from porcupine import dirs, get_tab_manager, add_quit_callback
+from porcupine import add_quit_callback, dirs, get_tab_manager
 from porcupine.settings import global_settings
 
 log = logging.getLogger(__name__)

--- a/porcupine/plugins/restart.py
+++ b/porcupine/plugins/restart.py
@@ -3,7 +3,8 @@ import logging
 import pickle
 from pathlib import Path
 
-from porcupine import dirs, get_main_window, get_tab_manager
+from porcupine import dirs, get_tab_manager, add_quit_callback
+from porcupine.settings import global_settings
 
 log = logging.getLogger(__name__)
 
@@ -14,24 +15,31 @@ STATE_FILE = Path(dirs.user_cache_dir) / "restart_state.pkl"
 setup_after = ["ttk_themes"]
 
 
-def save_states(junk: object) -> None:
+def quit_callback() -> bool:
     file_contents = []
-    selected_tab = get_tab_manager().select()
 
-    for tab in get_tab_manager().tabs():
-        state = tab.get_state()
-        if state is not None:
-            file_contents.append(
-                {"tab_type": type(tab), "tab_state": state, "selected": (tab == selected_tab)}
-            )
+    if global_settings.get("remember_tabs_on_restart", bool):
+        selected_tab = get_tab_manager().select()
+        for tab in get_tab_manager().tabs():
+            state = tab.get_state()
+            if state is not None:
+                file_contents.append(
+                    {"tab_type": type(tab), "tab_state": state, "selected": (tab == selected_tab)}
+                )
+    else:
+        # Ask user to save opened files
+        for tab in get_tab_manager().tabs():
+            if not tab.can_be_closed():
+                return False
 
     with STATE_FILE.open("wb") as file:
         pickle.dump(file_contents, file)
+    return True
 
 
 def setup() -> None:
     # this must run even if loading tabs from states below fails
-    get_main_window().bind("<<PorcupineQuit>>", save_states, add=True)
+    add_quit_callback(quit_callback)
 
     try:
         with STATE_FILE.open("rb") as file:

--- a/porcupine/plugins/restart.py
+++ b/porcupine/plugins/restart.py
@@ -3,7 +3,7 @@ import logging
 import pickle
 from pathlib import Path
 
-from porcupine import add_quit_callback, dirs, get_tab_manager
+from porcupine import add_quit_callback, dirs, get_tab_manager, settings
 from porcupine.settings import global_settings
 
 log = logging.getLogger(__name__)
@@ -38,6 +38,11 @@ def quit_callback() -> bool:
 
 
 def setup() -> None:
+    global_settings.add_option("remember_tabs_on_restart", default=True)
+    settings.add_checkbutton(
+        "remember_tabs_on_restart", text="Remember open tabs when Porcupine is closed and reopened"
+    )
+
     # this must run even if loading tabs from states below fails
     add_quit_callback(quit_callback)
 

--- a/porcupine/plugins/restart.py
+++ b/porcupine/plugins/restart.py
@@ -27,7 +27,7 @@ def quit_callback() -> bool:
                     {"tab_type": type(tab), "tab_state": state, "selected": (tab == selected_tab)}
                 )
     else:
-        # Ask user to save opened files
+        # Ask user to save changes in open tabs. They will soon be gone.
         for tab in get_tab_manager().tabs():
             if not tab.can_be_closed():
                 return False

--- a/porcupine/settings.py
+++ b/porcupine/settings.py
@@ -414,6 +414,7 @@ def _init_global_gui_settings() -> None:
     global_settings.add_option(
         "default_line_ending", LineEnding(os.linesep), converter=LineEnding.__getitem__
     )
+    global_settings.add_option("remember_tabs_on_restart", default=True)
 
     fixedfont = tkinter.font.Font(name="TkFixedFont", exists=True)
     if fixedfont["size"] < 0:
@@ -922,6 +923,7 @@ def _fill_dialog_content_with_defaults() -> None:
     add_combobox(
         "default_line_ending", "Default line ending:", values=[ending.name for ending in LineEnding]
     )
+    add_checkbutton("remember_tabs_on_restart", text="Remember opened tabs when Porcupine is closed and reopened")
     add_pygments_style_button("pygments_style", "Pygments style for editing:")
 
 

--- a/porcupine/settings.py
+++ b/porcupine/settings.py
@@ -923,7 +923,10 @@ def _fill_dialog_content_with_defaults() -> None:
     add_combobox(
         "default_line_ending", "Default line ending:", values=[ending.name for ending in LineEnding]
     )
-    add_checkbutton("remember_tabs_on_restart", text="Remember opened tabs when Porcupine is closed and reopened")
+    add_checkbutton(
+        "remember_tabs_on_restart",
+        text="Remember opened tabs when Porcupine is closed and reopened",
+    )
     add_pygments_style_button("pygments_style", "Pygments style for editing:")
 
 

--- a/porcupine/settings.py
+++ b/porcupine/settings.py
@@ -414,7 +414,6 @@ def _init_global_gui_settings() -> None:
     global_settings.add_option(
         "default_line_ending", LineEnding(os.linesep), converter=LineEnding.__getitem__
     )
-    global_settings.add_option("remember_tabs_on_restart", default=True)
 
     fixedfont = tkinter.font.Font(name="TkFixedFont", exists=True)
     if fixedfont["size"] < 0:
@@ -922,9 +921,6 @@ def _fill_dialog_content_with_defaults() -> None:
     add_spinbox("font_size", "Font size:", from_=3, to=1000)
     add_combobox(
         "default_line_ending", "Default line ending:", values=[ending.name for ending in LineEnding]
-    )
-    add_checkbutton(
-        "remember_tabs_on_restart", text="Remember open tabs when Porcupine is closed and reopened"
     )
     add_pygments_style_button("pygments_style", "Pygments style for editing:")
 

--- a/porcupine/settings.py
+++ b/porcupine/settings.py
@@ -924,8 +924,7 @@ def _fill_dialog_content_with_defaults() -> None:
         "default_line_ending", "Default line ending:", values=[ending.name for ending in LineEnding]
     )
     add_checkbutton(
-        "remember_tabs_on_restart",
-        text="Remember open tabs when Porcupine is closed and reopened",
+        "remember_tabs_on_restart", text="Remember open tabs when Porcupine is closed and reopened"
     )
     add_pygments_style_button("pygments_style", "Pygments style for editing:")
 

--- a/porcupine/settings.py
+++ b/porcupine/settings.py
@@ -925,7 +925,7 @@ def _fill_dialog_content_with_defaults() -> None:
     )
     add_checkbutton(
         "remember_tabs_on_restart",
-        text="Remember opened tabs when Porcupine is closed and reopened",
+        text="Remember open tabs when Porcupine is closed and reopened",
     )
     add_pygments_style_button("pygments_style", "Pygments style for editing:")
 

--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -838,6 +838,8 @@ class FileTab(Tab):
             msg = "Do you want to save your changes?"
         else:
             msg = f"Do you want to save your changes to {self.path.name}?"
+        
+        self.master.select(self)
         answer = messagebox.askyesnocancel("Close file", msg)
         if answer is None:
             # cancel

--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -838,7 +838,7 @@ class FileTab(Tab):
             msg = "Do you want to save your changes?"
         else:
             msg = f"Do you want to save your changes to {self.path.name}?"
-        
+
         self.master.select(self)
         answer = messagebox.askyesnocancel("Close file", msg)
         if answer is None:

--- a/tests/test_restart_plugin.py
+++ b/tests/test_restart_plugin.py
@@ -1,14 +1,14 @@
 import pytest
 
-from porcupine.tabs import Tab
-from porcupine.settings import global_settings
 from porcupine import get_main_window, get_tab_manager, quit
+from porcupine.settings import global_settings
+from porcupine.tabs import Tab
 
 
 @pytest.fixture
 def dont_remember_tabs_on_restart():
     # default value is True, set to False temporarily for testing
-    assert global_settings.get("remember_tabs_on_restart", bool)  
+    assert global_settings.get("remember_tabs_on_restart", bool)
     global_settings.set("remember_tabs_on_restart", False)
     yield
     global_settings.set("remember_tabs_on_restart", True)

--- a/tests/test_restart_plugin.py
+++ b/tests/test_restart_plugin.py
@@ -1,0 +1,55 @@
+import pytest
+
+from porcupine.tabs import Tab
+from porcupine.settings import global_settings
+from porcupine import get_main_window, get_tab_manager, quit
+
+
+@pytest.fixture
+def dont_remember_tabs_on_restart():
+    # default value is True, set to False temporarily for testing
+    assert global_settings.get("remember_tabs_on_restart", bool)  
+    global_settings.set("remember_tabs_on_restart", False)
+    yield
+    global_settings.set("remember_tabs_on_restart", True)
+
+
+def test_quit_without_remember_tabs_on_restart(mocker, dont_remember_tabs_on_restart):
+    doesnt_wanna_close = Tab(get_tab_manager())
+    doesnt_wanna_close.can_be_closed = mocker.Mock()
+    doesnt_wanna_close.can_be_closed.return_value = False
+    get_tab_manager().add_tab(Tab(get_tab_manager()))
+    get_tab_manager().add_tab(doesnt_wanna_close)
+    get_tab_manager().add_tab(Tab(get_tab_manager()))
+
+    assert len(get_tab_manager().tabs()) == 3
+
+    quit()  # should do nothing, because one tab doesn't want to be closed
+    assert len(get_tab_manager().tabs()) == 3
+    doesnt_wanna_close.can_be_closed.assert_called_once_with()
+
+    # Close the offending tab. Then quitting should be possible.
+    get_tab_manager().close_tab(doesnt_wanna_close)
+    assert len(get_tab_manager().tabs()) == 2
+
+    # Prevent quit() from breaking the rest of tests
+    mocked_destroy = mocker.patch("tkinter.Tk.destroy")
+    quit()
+    mocked_destroy.assert_called_once_with()
+    assert len(get_tab_manager().tabs()) == 0
+
+
+def test_quit_with_remember_tabs_on_restart(mocker):
+    doesnt_wanna_close = Tab(get_tab_manager())
+    doesnt_wanna_close.can_be_closed = mocker.Mock()
+    doesnt_wanna_close.can_be_closed.return_value = False
+    get_tab_manager().add_tab(Tab(get_tab_manager()))
+    get_tab_manager().add_tab(doesnt_wanna_close)
+    get_tab_manager().add_tab(Tab(get_tab_manager()))
+    assert len(get_tab_manager().tabs()) == 3
+
+    # Prevent quit() from breaking the rest of tests
+    mocked_destroy = mocker.patch("tkinter.Tk.destroy")
+    quit()
+    mocked_destroy.assert_called_once_with()
+    assert len(get_tab_manager().tabs()) == 0

--- a/tests/test_restart_plugin.py
+++ b/tests/test_restart_plugin.py
@@ -1,6 +1,6 @@
 import pytest
 
-from porcupine import get_main_window, get_tab_manager, quit
+from porcupine import get_tab_manager, quit
 from porcupine.settings import global_settings
 from porcupine.tabs import Tab
 


### PR DESCRIPTION
This makes Porcupine work better for the "two different ways to use Porcupine" I explained in #1078. Will conflict with #1078.