### PR TITLE
Update pygments and fix dpaste highlighting logic

### DIFF
--- a/porcupine/plugins/pastebin.py
+++ b/porcupine/plugins/pastebin.py
@@ -129,6 +129,58 @@ class DPaste(Paste):
             return None
         return cast(ssl.SSLSocket, self.connection.sock)
 
+    @staticmethod
+    def get_dpaste_name_for_lexer_class(lexer_class: LexerMeta) -> str:
+        special_cases = {
+            "actionscript3": "as3",
+            "actionscript": "as",
+            "ambienttalk": "at",
+            "antlr-actionscript": "antlr-as",
+            "asymptote": "asy",
+            "autohotkey": "ahk",
+            "batch": "bat",
+            "bibtex": "bib",
+            "chaiscript": "chai",
+            "javascript+cheetah": "js+cheetah",
+            "coffeescript": "coffee-script",
+            "css+ruby": "css+erb",
+            "debcontrol": "control",
+            "emacs-lisp": "emacs",
+            "gherkin": "cucumber",
+            "haxe": "hx",
+            "javascript+django": "js+django",
+            "javascript+ruby": "js+erb",
+            "javascript": "js",
+            "javascript+php": "js+php",
+            "javascript+smarty": "js+smarty",
+            "javascript+lasso": "js+lasso",
+            "lighttpd": "lighty",
+            "literate-agda": "lagda",
+            "literate-cryptol": "lcry",
+            "literate-haskell": "lhs",
+            "literate-idris": "lidr",
+            "livescript": "live-script",
+            "javascript+mako": "js+mako",
+            "markdown": "md",
+            "miniscript": "ms",
+            "moonscript": "moon",
+            "javascript+myghty": "js+myghty",
+            "nimrod": "nim",
+            "pwsh-session": "ps1con",
+            "rng-compact": "rnc",
+            "reasonml": "reason",
+            "resourcebundle": "resource",
+            "restructuredtext": "rst",
+            "trafficscript": "rts",
+            "ruby": "rb",
+            "debsources": "sourceslist",
+            "supercollider": "sc",
+            "teratermmacro": "ttl",
+            "typescript": "ts",
+            "xml+ruby": "xml+erb",
+        }
+        return special_cases.get(lexer_class.aliases[0], lexer_class.aliases[0])
+
     def run(self, code: str, lexer_class: LexerMeta) -> str:
         # kwargs of do_open() go to MyHTTPSConnection
         handler = HTTPSHandler()
@@ -138,7 +190,9 @@ class DPaste(Paste):
         # dpaste.com's syntax highlighting choices correspond with pygments lexers (see tests)
         request = Request(
             DPASTE_URL,
-            data=urlencode({"syntax": lexer_class.aliases[0], "content": code}).encode("utf-8"),
+            data=urlencode(
+                {"syntax": self.get_dpaste_name_for_lexer_class(lexer_class), "content": code}
+            ).encode("utf-8"),
         )
 
         with build_opener(handler).open(request) as response:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 appdirs>=1.4.4
 # pygments version fixed because haxx in highlight plugin
-Pygments==2.7.4
+Pygments==2.12.0
 toposort>=1.5
 colorama>=0.2.5
 sansio-lsp-client>=0.10.0,<0.11.0

--- a/tests/test_pastebin_plugin.py
+++ b/tests/test_pastebin_plugin.py
@@ -9,7 +9,7 @@ from http.client import RemoteDisconnected
 
 import pytest
 import requests
-from pygments.lexers import PythonLexer, TextLexer, get_lexer_by_name
+from pygments.lexers import PythonLexer, TextLexer, find_lexer_class_by_name
 
 from porcupine import get_main_window, utils
 from porcupine.plugins.pastebin import DPaste, SuccessDialog, Termbin
@@ -36,34 +36,15 @@ def test_dpaste_syntax_choices():
     response.raise_for_status()
     syntax_choices = response.json()
 
-    # These are wrong for whatever reason (different pygments versions?)
-    del syntax_choices["amdgpu"]
-    del syntax_choices["ansys"]
-    del syntax_choices["asc"]
-    del syntax_choices["cddl"]
-    del syntax_choices["futhark"]
-    del syntax_choices["gcode"]
-    del syntax_choices["graphviz"]
-    del syntax_choices["gsql"]
+    # These are wrong for whatever reason, can look into them if it bothers someone
+    del syntax_choices["json-object"]
     del syntax_choices["ipython2"]
     del syntax_choices["ipython3"]
     del syntax_choices["ipythonconsole"]
-    del syntax_choices["jslt"]
-    del syntax_choices["json-object"]
-    del syntax_choices["kuin"]
-    del syntax_choices["meson"]
-    del syntax_choices["nestedtext"]
-    del syntax_choices["nodejsrepl"]
-    del syntax_choices["omg-idl"]
-    del syntax_choices["output"]
-    del syntax_choices["procfile"]
-    del syntax_choices["smithy"]
-    del syntax_choices["teal"]
-    del syntax_choices["ti"]
-    del syntax_choices["wast"]
 
     for syntax_choice in syntax_choices.keys():
-        assert syntax_choice == get_lexer_by_name(syntax_choice).aliases[0]
+        lexer_class = find_lexer_class_by_name(syntax_choice)
+        assert syntax_choice == DPaste.get_dpaste_name_for_lexer_class(lexer_class)
 
 
 @pytest.mark.pastebin_test


### PR DESCRIPTION
Because dpaste.com isn't open source, there's no good way to know what exactly they are doing with pygments lexers. I tried at least `lexer_class.aliases[0]` (first alias), `min(lexer_class.aliases, key=len)` (shortest alias) and `lexer_class.name.lower()`. Turns out that taking the  first alias works best, but still produces some false positives that I fixed with a hard-coded mapping.