### PR TITLE
Use tkinter's destroy method in ask_encoding()

### DIFF
--- a/porcupine/utils.py
+++ b/porcupine/utils.py
@@ -646,7 +646,7 @@ _list_of_encodings = [
 # TODO: document this?
 def ask_encoding(text: str, old_encoding: str) -> str | None:
     if porcupine.get_main_window().tk.call("winfo", "exists", ".choose_encoding"):
-        porcupine.get_main_window().tk.call("destroy", ".choose_encoding")
+        porcupine.get_main_window().nametowidget(".choose_encoding").destroy()
 
     dialog = tkinter.Toplevel(name="choose_encoding")
     if porcupine.get_main_window().winfo_viewable():


### PR DESCRIPTION
`tkinter.Toplevel.destroy()` (which is actually `tkinter.BaseWidget.destroy()`) does quite a bit of cleanup other than just calling the Tcl `destroy` command. Here are the relevant parts of tkinter's source code:

```python3
class Misc:
    def destroy(self):
        if self._tclCommands is not None:
            for name in self._tclCommands:
                #print '- Tkinter: deleted command', name
                self.tk.deletecommand(name)
            self._tclCommands = None

class BaseWidget(Misc):
    def destroy(self):
        for c in list(self.children.values()): c.destroy()
        self.tk.call('destroy', self._w)
        if self._name in self.master.children:
            del self.master.children[self._name]
        Misc.destroy(self)
```

We probably don't want to skip all that.