### PR TITLE
Rewrite utils.quote in a much simpler way

### DIFF
--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -54,11 +54,4 @@ Miscellaneous
 .. autofunction:: backup_open
 .. autofunction:: find_project_root
 .. autofunction:: copy_type
-
-.. function:: quote(argument)
-
-   Add quotes around an argument of a command.
-
-   This function is equivalent to :func:`shlex.quote` on non-Windows systems,
-   and on Windows it adds double quotes in a similar way. This is useful for
-   running commands in the Windows command prompt or a POSIX-compatible shell.
+.. autofunction:: quote

--- a/porcupine/utils.py
+++ b/porcupine/utils.py
@@ -43,45 +43,11 @@ else:
     python_executable = Path(sys.executable)
 
 
-if sys.platform == "win32":
-    # this is mostly copy/pasted from subprocess.list2cmdline
-    def quote(string: str) -> str:
-        result = []
-        needquote = False
-        bs_buf = []
-
-        needquote = (" " in string) or ("\t" in string) or not string
-        if needquote:
-            result.append('"')
-
-        for c in string:
-            if c == "\\":
-                # Don't know if we need to double yet.
-                bs_buf.append(c)
-            elif c == '"':
-                # Double backslashes.
-                result.append("\\" * len(bs_buf) * 2)
-                bs_buf = []
-                result.append('\\"')
-            else:
-                # Normal char
-                if bs_buf:
-                    result.extend(bs_buf)
-                    bs_buf = []
-                result.append(c)
-
-        # Add remaining backslashes, if any.
-        if bs_buf:
-            result.extend(bs_buf)
-
-        if needquote:
-            result.extend(bs_buf)
-            result.append('"')
-
-        return "".join(result)
-
-else:
-    quote = shlex.quote
+def quote(string: str) -> str:
+    if sys.platform == "win32":
+        return subprocess.list2cmdline([string])
+    else:
+        return shlex.quote(string)
 
 
 # https://github.com/python/typing/issues/769

--- a/porcupine/utils.py
+++ b/porcupine/utils.py
@@ -44,6 +44,12 @@ else:
 
 
 def quote(string: str) -> str:
+    """Add quotes around an argument of a command.
+
+    This function is equivalent to :func:`shlex.quote` on non-Windows systems,
+    and on Windows it adds double quotes in a similar way. This is useful for
+    running commands in the Windows command prompt or a POSIX-compatible shell.
+    """
     if sys.platform == "win32":
         return subprocess.list2cmdline([string])
     else:


### PR DESCRIPTION
A script to ensure this doesn't change how the function behaves:

```python3
import itertools
from subprocess import list2cmdline


# copy/pasted from porcupine.utils
def quote(string: str) -> str:
    result = []
    needquote = False
    bs_buf = []

    needquote = (" " in string) or ("\t" in string) or not string
    if needquote:
        result.append('"')

    for c in string:
        if c == "\\":
            # Don't know if we need to double yet.
            bs_buf.append(c)
        elif c == '"':
            # Double backslashes.
            result.append("\\" * len(bs_buf) * 2)
            bs_buf = []
            result.append('\\"')
        else:
            # Normal char
            if bs_buf:
                result.extend(bs_buf)
                bs_buf = []
            result.append(c)

    # Add remaining backslashes, if any.
    if bs_buf:
        result.extend(bs_buf)

    if needquote:
        result.extend(bs_buf)
        result.append('"')

    return "".join(result)


alphabet = '"' + r"'Aa1ö\/?!£@$"
for length in range(7):
    print("Testing length", length)
    for chars in itertools.product(alphabet, repeat=length):
        string = "".join(chars)
        assert quote(string) == list2cmdline([string])
```