### PR TITLE
Allow passing --verbose-logger multiple times

### DIFF
--- a/porcupine/__main__.py
+++ b/porcupine/__main__.py
@@ -51,6 +51,7 @@ def main() -> None:
     verbose_group.add_argument(
         "-v",
         "--verbose",
+        action="store_true",
         help=(
             "print all logging messages to stderr, only warnings and errors "
             "are printed by default (but all messages always go to a log "

--- a/porcupine/__main__.py
+++ b/porcupine/__main__.py
@@ -51,9 +51,6 @@ def main() -> None:
     verbose_group.add_argument(
         "-v",
         "--verbose",
-        dest="verbose_logger",
-        action="store_const",
-        const="",
         help=(
             "print all logging messages to stderr, only warnings and errors "
             "are printed by default (but all messages always go to a log "
@@ -62,6 +59,7 @@ def main() -> None:
     )
     verbose_group.add_argument(
         "--verbose-logger",
+        action="append",  # Allow passing multiple times: --verbose-logger foo --verbose-logger bar
         help=(
             "increase verbosity for just one logger only, e.g. "
             "--verbose-logger=porcupine.plugins.highlight "
@@ -94,7 +92,10 @@ def main() -> None:
     Path(dirs.user_cache_dir).mkdir(parents=True, exist_ok=True)
     (Path(dirs.user_config_dir) / "plugins").mkdir(parents=True, exist_ok=True)
     Path(dirs.user_log_dir).mkdir(parents=True, exist_ok=True)
-    _logs.setup(args_parsed_in_first_step.verbose_logger)
+    _logs.setup(
+        all_loggers_verbose=args_parsed_in_first_step.verbose,
+        verbose_loggers=(args_parsed_in_first_step.verbose_logger or []),
+    )
 
     settings.init_enough_for_using_disabled_plugins_list()
     if args_parsed_in_first_step.use_plugins:

--- a/porcupine/_logs.py
+++ b/porcupine/_logs.py
@@ -9,7 +9,7 @@ import sys
 import threading
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, TextIO, cast
+from typing import Any, Sequence, TextIO, cast
 
 import porcupine
 from porcupine import dirs
@@ -62,7 +62,7 @@ def _open_log_file() -> TextIO:
     assert False  # makes mypy happy
 
 
-def setup(*, all_loggers_verbose: bool, verbose_loggers: list[str]) -> None:
+def setup(*, all_loggers_verbose: bool = False, verbose_loggers: Sequence[str] = ()) -> None:
     handlers: list[logging.Handler] = []
 
     log_file = _open_log_file()
@@ -78,8 +78,14 @@ def setup(*, all_loggers_verbose: bool, verbose_loggers: list[str]) -> None:
     if sys.stderr is not None:
         # not running in pythonw.exe, can also show something in terminal
         print_handler = logging.StreamHandler(sys.stderr)
-        print_handler.setLevel(logging.DEBUG)
-        if not all_loggers_verbose:
+        if all_loggers_verbose:
+            print_handler.setLevel(logging.DEBUG)
+        elif not verbose_loggers:
+            print_handler.setLevel(logging.WARNING)
+        else:
+            # Filter manually. It is possible to set verbosities for each logger,
+            # but that would also affect what goes to the log file, not good.
+            print_handler.setLevel(logging.DEBUG)
             print_handler.addFilter(
                 lambda record: (
                     # Always show warnings and errors

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -60,7 +60,7 @@ def test_log_path_printed(mocker):
     mock = mocker.patch("porcupine._logs.print")
     mock.side_effect = ZeroDivisionError  # to make it stop when it prints
     with pytest.raises(ZeroDivisionError):
-        _logs.setup(None)
+        _logs.setup()
 
     mock.assert_called_once()
     [printed] = mock.call_args[0]


### PR DESCRIPTION
While working on #1114, I tried:

```
python3 -m porcupine --verbose-logger=porcupine.plugins.pygments_highlight --verbose-logger=porcupine.plugins.tree_sitter_highlight
```

Before this PR, only the second `--verbose-logger` does something. The output is:

```
log file: /home/akuli/.cache/porcupine/log/2022-08-06T15-47-37.txt
porcupine.plugins.tree_sitter_highlight DEBUG: ran tree_sitter_highlight.setup() in 34.375 milliseconds
```

After this PR, both work:

```
log file: /home/akuli/.cache/porcupine/log/2022-08-06T15-48-30.txt
porcupine.plugins.pygments_highlight DEBUG: ran pygments_highlight.setup() in 0.499 milliseconds
porcupine.plugins.tree_sitter_highlight DEBUG: ran tree_sitter_highlight.setup() in 37.312 milliseconds
```

