### PR TITLE
Use tree-sitter queries for rust highlighter

### DIFF
--- a/porcupine/plugins/highlight/tree-sitter-token-mappings/rust.yml
+++ b/porcupine/plugins/highlight/tree-sitter-token-mappings/rust.yml
@@ -1,9 +1,6 @@
 dont_recurse_inside:
   - string
   - attribute
-  # recursing inside scoped_identifier would break highlighting of tokio::select!
-  # TODO: Vec::foo() doesn't highlight properly
-  - scoped_identifier
   - string_literal
   - attribute_item
 

--- a/porcupine/plugins/highlight/tree-sitter-token-mappings/rust.yml
+++ b/porcupine/plugins/highlight/tree-sitter-token-mappings/rust.yml
@@ -7,6 +7,17 @@ dont_recurse_inside:
   - string_literal
   - attribute_item
 
+queries:
+  macro_invocation: |
+    (macro_invocation
+      # Many themes have a nice decorator color (lol), use it for macro name
+      # Example: in "tokio::select! { ... }", the "tokio::select!" part is decorator-colored
+      macro: (_) @Token.Name.Decorator
+      "!" @Token.Name.Decorator
+      # Recurse into macro body, which seems to always be a token_tree node
+      (token_tree) @recurse
+    )
+
 token_mapping:
   line_comment: Token.Comment
   block_comment: Token.Comment
@@ -44,7 +55,6 @@ token_mapping:
   mod: Token.Keyword
   crate: Token.Keyword
   attribute_item: Token.Name.Decorator  # lol
-  macro_invocation: Token.Name.Decorator  # lol
   primitive_type: Token.Keyword
   'true': Token.Keyword
   'false': Token.Keyword

--- a/porcupine/plugins/highlight/tree_sitter_highlighter.py
+++ b/porcupine/plugins/highlight/tree_sitter_highlighter.py
@@ -130,18 +130,11 @@ class TreeSitterHighlighter(BaseHighlighter):
         #    type='pair' text=b'y=2'
         #
         # I want the whole section header [foo] to have the same tag.
-        #
-        # There's a similar situation in rust: macro name is just an identifier in a macro_invocation
         if (
             self._language.name == "toml"
             and node.type not in ("pair", "comment")
             and node.parent is not None
             and node.parent.type in ("table", "table_array_element")
-        ) or (
-            self._language.name == "rust"
-            and node.type in ("identifier", "scoped_identifier", "!")
-            and node.parent is not None
-            and node.parent.type == "macro_invocation"
         ):
             type_name = node.parent.type
         else:


### PR DESCRIPTION
- Now highlights `Vec` as a built-in when you do `Vec::from_iter(blah)`.
- No longer rust-specific code in `tree_sitter_highlighter.py`.