### PR TITLE
When applying a filetype, defer generating change events until the whole filetype set

### DIFF
--- a/porcupine/plugins/filetypes.py
+++ b/porcupine/plugins/filetypes.py
@@ -210,10 +210,11 @@ def apply_filetype_to_tab(filetype: FileType, tab: tabs.FileTab) -> None:
     log.info(f"applying filetype settings: {filetype!r}")
 
     previously_set = tab.settings.get_options_by_tag("from_filetype")
-    for name, value in filetype.items():
-        # Ignore stuff used only for guessing the correct filetype
-        if name not in {"filename_patterns", "shebang_regex"}:
-            tab.settings.set(name, value, from_config=True, tag="from_filetype")
+    with tab.settings.set_many_at_once():
+        for name, value in filetype.items():
+            # Ignore stuff used only for guessing the correct filetype
+            if name not in {"filename_patterns", "shebang_regex"}:
+                tab.settings.set(name, value, from_config=True, tag="from_filetype")
 
     # Avoid resetting an option before setting its value.
     # If the option's value doesn't change, that would create unnecessary change events.

--- a/porcupine/plugins/filetypes.py
+++ b/porcupine/plugins/filetypes.py
@@ -216,13 +216,14 @@ def apply_filetype_to_tab(filetype: FileType, tab: tabs.FileTab) -> None:
             if name not in {"filename_patterns", "shebang_regex"}:
                 tab.settings.set(name, value, from_config=True, tag="from_filetype")
 
-    # Avoid resetting an option before setting its value.
-    # If the option's value doesn't change, that would create unnecessary change events.
-    # For example, when you rename a file, it would temporarily reset the "langserver" setting.
-    # That would cause the langserver to be restarted unnecessarily.
-    needs_reset = previously_set - filetype.keys()
-    for name in needs_reset:
-        tab.settings.reset(name)
+        # Avoid resetting an option before setting its value.
+        # If the option's value doesn't change, that would create unnecessary change events.
+        # For example, when you rename a file, it would temporarily reset the "langserver" setting.
+        # That would cause the langserver to be restarted unnecessarily.
+        # Alternatively we could make settings.set_many_at_once() more clever to handle this :)
+        needs_reset = previously_set - filetype.keys()
+        for name in needs_reset:
+            tab.settings.reset(name)
 
 
 def on_path_changed(tab: tabs.FileTab, junk: object = None) -> None:

--- a/porcupine/plugins/filetypes.py
+++ b/porcupine/plugins/filetypes.py
@@ -211,8 +211,7 @@ def apply_filetype_to_tab(filetype: FileType, tab: tabs.FileTab) -> None:
 
     with tab.settings.set_many_at_once():
         # Reset all options whose values came from the previous filetype.
-        needs_reset = tab.settings.get_options_by_tag("from_filetype") - filetype.keys()
-        for name in needs_reset:
+        for name in tab.settings.get_options_by_tag("from_filetype"):
             tab.settings.reset(name)
 
         for name, value in filetype.items():

--- a/porcupine/plugins/filetypes.py
+++ b/porcupine/plugins/filetypes.py
@@ -220,7 +220,6 @@ def apply_filetype_to_tab(filetype: FileType, tab: tabs.FileTab) -> None:
                 tab.settings.set(name, value, from_config=True, tag="from_filetype")
 
 
-
 def on_path_changed(tab: tabs.FileTab, junk: object = None) -> None:
     log.info(f"file path changed: {tab.path}")
     apply_filetype_to_tab(get_filetype_for_tab(tab), tab)

--- a/porcupine/plugins/filetypes.py
+++ b/porcupine/plugins/filetypes.py
@@ -209,7 +209,7 @@ def get_filetype_for_tab(tab: tabs.FileTab) -> FileType:
 def apply_filetype_to_tab(filetype: FileType, tab: tabs.FileTab) -> None:
     log.info(f"applying filetype settings: {filetype!r}")
 
-    with tab.settings.set_many_at_once():
+    with tab.settings.defer_change_events():
         # Reset all options whose values came from the previous filetype.
         for name in tab.settings.get_options_by_tag("from_filetype"):
             tab.settings.reset(name)

--- a/porcupine/plugins/highlight/__init__.py
+++ b/porcupine/plugins/highlight/__init__.py
@@ -49,7 +49,9 @@ class HighlighterManager:
             if language_name is None:
                 # TODO: set all highlighter settings at once, so that this doesn't happen in the
                 # middle of applying filetype settings
-                log.info("highlighter_name set to 'tree_sitter' even though tree_sitter_language_name is unset")
+                log.info(
+                    "highlighter_name set to 'tree_sitter' even though tree_sitter_language_name is unset"
+                )
                 return
             log.info(f"creating a tree_sitter highlighter with language {repr(language_name)}")
             self._highlighter = TreeSitterHighlighter(self._tab.textwidget, language_name)

--- a/porcupine/plugins/highlight/__init__.py
+++ b/porcupine/plugins/highlight/__init__.py
@@ -45,14 +45,7 @@ class HighlighterManager:
             return
 
         if highlighter_name == "tree_sitter":
-            language_name = self._tab.settings.get("tree_sitter_language_name", Optional[str])
-            if language_name is None:
-                # TODO: set all highlighter settings at once, so that this doesn't happen in the
-                # middle of applying filetype settings
-                log.info(
-                    "highlighter_name set to 'tree_sitter' even though tree_sitter_language_name is unset"
-                )
-                return
+            language_name = self._tab.settings.get("tree_sitter_language_name", str)
             log.info(f"creating a tree_sitter highlighter with language {repr(language_name)}")
             self._highlighter = TreeSitterHighlighter(self._tab.textwidget, language_name)
         elif highlighter_name == "pygments":

--- a/porcupine/plugins/highlight/__init__.py
+++ b/porcupine/plugins/highlight/__init__.py
@@ -45,14 +45,7 @@ class HighlighterManager:
             return
 
         if highlighter_name == "tree_sitter":
-            language_name = self._tab.settings.get("tree_sitter_language_name", Optional[str])
-            if language_name is None:
-                # TODO: set all highlighter settings at once, so that this doesn't happen in the
-                # middle of applying filetype settings
-                log.info(
-                    "highlighter_name set to 'tree_sitter' even though tree_sitter_language_name is unset"
-                )
-                return
+            language_name = self._tab.settings.get("tree_sitter_language_name", str)
             log.info(f"creating a tree_sitter highlighter with language {repr(language_name)}")
             self._highlighter = TreeSitterHighlighter(self._tab.textwidget, language_name)
         elif highlighter_name == "pygments":
@@ -110,7 +103,9 @@ def debounce(
 def on_new_filetab(tab: tabs.FileTab) -> None:
     # pygments_lexer option already exists, as it is used also outside this plugin
     tab.settings.add_option("syntax_highlighter", default="pygments")
-    tab.settings.add_option("tree_sitter_language_name", default=None, type_=Optional[str])
+    tab.settings.add_option(
+        "tree_sitter_language_name", default="<tree_sitter_language_name not set>"
+    )
 
     manager = HighlighterManager(tab)
     tab.bind("<<TabSettingChanged:pygments_lexer>>", manager.on_config_changed, add=True)

--- a/porcupine/plugins/highlight/__init__.py
+++ b/porcupine/plugins/highlight/__init__.py
@@ -108,7 +108,7 @@ def on_new_filetab(tab: tabs.FileTab) -> None:
     manager = HighlighterManager(tab)
     tab.bind("<<TabSettingChanged:pygments_lexer>>", manager.on_config_changed, add=True)
     tab.bind("<<TabSettingChanged:syntax_highlighter>>", manager.on_config_changed, add=True)
-    tab.bind("<<TabSettingChanged:tree_sitter>>", manager.on_config_changed, add=True)
+    tab.bind("<<TabSettingChanged:tree_sitter_language_name>>", manager.on_config_changed, add=True)
     manager.on_config_changed()
 
     utils.bind_with_data(tab.textwidget, "<<ContentChanged>>", manager.on_change_event, add=True)

--- a/porcupine/plugins/highlight/__init__.py
+++ b/porcupine/plugins/highlight/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import sys
 import tkinter
-from typing import Callable
+from typing import Callable, Optional
 
 from pygments.lexer import LexerMeta
 
@@ -45,7 +45,12 @@ class HighlighterManager:
             return
 
         if highlighter_name == "tree_sitter":
-            language_name = self._tab.settings.get("tree_sitter_language_name", str)
+            language_name = self._tab.settings.get("tree_sitter_language_name", Optional[str])
+            if language_name is None:
+                # TODO: set all highlighter settings at once, so that this doesn't happen in the
+                # middle of applying filetype settings
+                log.info("highlighter_name set to 'tree_sitter' even though tree_sitter_language_name is unset")
+                return
             log.info(f"creating a tree_sitter highlighter with language {repr(language_name)}")
             self._highlighter = TreeSitterHighlighter(self._tab.textwidget, language_name)
         elif highlighter_name == "pygments":
@@ -103,7 +108,7 @@ def debounce(
 def on_new_filetab(tab: tabs.FileTab) -> None:
     # pygments_lexer option already exists, as it is used also outside this plugin
     tab.settings.add_option("syntax_highlighter", default="pygments")
-    tab.settings.add_option("tree_sitter_language_name", default="<missing>")
+    tab.settings.add_option("tree_sitter_language_name", default=None, type_=Optional[str])
 
     manager = HighlighterManager(tab)
     tab.bind("<<TabSettingChanged:pygments_lexer>>", manager.on_config_changed, add=True)

--- a/porcupine/plugins/highlight/__init__.py
+++ b/porcupine/plugins/highlight/__init__.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import sys
 import tkinter
-from typing import Callable, Optional
+from typing import Callable
 
 from pygments.lexer import LexerMeta
 

--- a/porcupine/settings.py
+++ b/porcupine/settings.py
@@ -233,7 +233,7 @@ class Settings:
 
     # TODO: document this
     @contextlib.contextmanager
-    def set_many_at_once(self) -> Generator[None, None, None]:
+    def defer_change_events(self) -> Generator[None, None, None]:
         if self._pending_change_events is not None:
             raise RuntimeError("calls to set_batch() cannot be nested")
 

--- a/porcupine/settings.py
+++ b/porcupine/settings.py
@@ -229,7 +229,7 @@ class Settings:
     @contextlib.contextmanager
     def set_many_at_once(self) -> Generator[None, None, None]:
         if self._pending_change_events is not None:
-            raise RuntimeError( "calls to set_batch() cannot be nested")
+            raise RuntimeError("calls to set_batch() cannot be nested")
 
         self._pending_change_events = {}
         try:

--- a/porcupine/settings.py
+++ b/porcupine/settings.py
@@ -208,7 +208,9 @@ class Settings:
                 # can be an error from converter
                 _log.exception(f"setting {option_name!r} to {unknown.value!r} failed")
 
-    def _generate_change_event(self, option_name: str, old_value: object, new_value: object) -> None:
+    def _generate_change_event(
+        self, option_name: str, old_value: object, new_value: object
+    ) -> None:
         event_name = self._change_event_format.format(option_name)
         if old_value == new_value:
             _log.debug(f"not generating a change event because value didn't change: {event_name}")

--- a/porcupine/settings.py
+++ b/porcupine/settings.py
@@ -235,7 +235,7 @@ class Settings:
     @contextlib.contextmanager
     def defer_change_events(self) -> Generator[None, None, None]:
         if self._pending_change_events is not None:
-            raise RuntimeError("calls to set_batch() cannot be nested")
+            raise RuntimeError("calls to defer_change_events() cannot be nested")
 
         self._pending_change_events = {}
         try:

--- a/porcupine/settings.py
+++ b/porcupine/settings.py
@@ -124,7 +124,7 @@ class Settings:
         self._unknown_options: dict[str, _UnknownOption] = {}
         self._change_event_widget = change_event_widget  # None to notify all widgets
         self._change_event_format = change_event_format
-        self._pending_change_events: list[tuple[str, object]] | None = None
+        self._pending_change_events: dict[str, object] | None = None
 
     def add_option(
         self,
@@ -231,12 +231,12 @@ class Settings:
         if self._pending_change_events is not None:
             raise RuntimeError( "calls to set_batch() cannot be nested")
 
-        self._pending_change_events = []
+        self._pending_change_events = {}
         try:
             yield
         finally:
             try:
-                for option_name, value in self._pending_change_events:
+                for option_name, value in self._pending_change_events.items():
                     self._generate_change_event(option_name, value)
             finally:
                 self._pending_change_events = None
@@ -292,7 +292,7 @@ class Settings:
         if self._pending_change_events is None:
             self._generate_change_event(option_name, value)
         else:
-            self._pending_change_events.append((option_name, value))
+            self._pending_change_events[option_name] = value
 
     def get_options_by_tag(self, tag: str) -> builtins.set[str]:
         """Return the names of all options whose current value was set with the given ``tag``."""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -238,6 +238,7 @@ def test_change_events(toplevel):
 
     change_events.clear()
     with settings_obj.set_many_at_once():
+        settings_obj.set("foo", "some temporary value")
         settings_obj.set("foo", "xxx")
         settings_obj.set("bar", "yyy")
         assert change_events == []

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -224,11 +224,11 @@ def test_change_events(toplevel):
     change_events = []
     toplevel.bind(
         "<<ItChanged:foo>>",
-        (lambda e: change_events.append("foo = " + settings_obj.get('foo', str))),
+        (lambda e: change_events.append("foo = " + settings_obj.get("foo", str))),
     )
     toplevel.bind(
         "<<ItChanged:bar>>",
-        (lambda e: change_events.append("bar = " + settings_obj.get('bar', str))),
+        (lambda e: change_events.append("bar = " + settings_obj.get("bar", str))),
     )
 
     settings_obj.set("foo", "x")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -239,7 +239,7 @@ def test_change_events(toplevel):
     assert change_events == ["foo = x", "bar = y"]
 
     change_events.clear()
-    with settings_obj.set_many_at_once():
+    with settings_obj.defer_change_events():
         settings_obj.set("foo", "some temporary value")
         settings_obj.set("foo", "xxx")
         settings_obj.set("bar", "yyy")
@@ -247,14 +247,14 @@ def test_change_events(toplevel):
     assert change_events == ["foo = xxx", "bar = yyy"]
 
     change_events.clear()
-    with settings_obj.set_many_at_once():
+    with settings_obj.defer_change_events():
         settings_obj.set("foo", "asd asd")
         settings_obj.set("foo", "xxx")
     assert change_events == []  # change was ignored: "xxx" --> "asd asd" --> "xxx"
 
-    with settings_obj.set_many_at_once():
+    with settings_obj.defer_change_events():
         with pytest.raises(RuntimeError, match="cannot be nested"):
-            with settings_obj.set_many_at_once():
+            with settings_obj.defer_change_events():
                 pass
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -246,6 +246,12 @@ def test_change_events(toplevel):
         assert change_events == []
     assert change_events == ["foo = xxx", "bar = yyy"]
 
+    change_events.clear()
+    with settings_obj.set_many_at_once():
+        settings_obj.set("foo", "asd asd")
+        settings_obj.set("foo", "xxx")
+    assert change_events == []  # change was ignored: "xxx" --> "asd asd" --> "xxx"
+
     with settings_obj.set_many_at_once():
         with pytest.raises(RuntimeError, match="cannot be nested"):
             with settings_obj.set_many_at_once():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -225,10 +225,12 @@ def test_change_events(toplevel):
     toplevel.bind(
         "<<ItChanged:foo>>",
         (lambda e: change_events.append("foo = " + settings_obj.get("foo", str))),
+        add=True,
     )
     toplevel.bind(
         "<<ItChanged:bar>>",
         (lambda e: change_events.append("bar = " + settings_obj.get("bar", str))),
+        add=True,
     )
 
     settings_obj.set("foo", "x")


### PR DESCRIPTION
Makes it impossible to have other issues similar to #1145. I think that's important, because bugs like this apparently take some time to discover (a few days for #1145) and the resulting behavior can be very weird.