### PR TITLE
Get vendored py-tree-sitter-languages wheels from a specific commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,10 @@ PyYAML==6.0
 # TODO: get rid of wheel files committed to this repo when my windows PR
 # to tree-sitter-languages gets released
 tree-sitter-languages==1.3.0; sys_platform != 'win32'
-tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/py-tree-sitter-builds/vendor/tree_sitter_languages-1.3.0-cp37-cp37m-win_amd64.whl ; python_version == '3.7' and sys_platform == 'win32'
-tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/py-tree-sitter-builds/vendor/tree_sitter_languages-1.3.0-cp38-cp38-win_amd64.whl ; python_version == '3.8' and sys_platform == 'win32'
-tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/py-tree-sitter-builds/vendor/tree_sitter_languages-1.3.0-cp39-cp39-win_amd64.whl ; python_version == '3.9' and sys_platform == 'win32'
-tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/py-tree-sitter-builds/vendor/tree_sitter_languages-1.3.0-cp310-cp310-win_amd64.whl ; python_version == '3.10' and sys_platform == 'win32'
+tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/master/vendor/tree_sitter_languages-1.3.0-cp37-cp37m-win_amd64.whl ; python_version == '3.7' and sys_platform == 'win32'
+tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/master/vendor/tree_sitter_languages-1.3.0-cp38-cp38-win_amd64.whl ; python_version == '3.8' and sys_platform == 'win32'
+tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/master/vendor/tree_sitter_languages-1.3.0-cp39-cp39-win_amd64.whl ; python_version == '3.9' and sys_platform == 'win32'
+tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/master/vendor/tree_sitter_languages-1.3.0-cp310-cp310-win_amd64.whl ; python_version == '3.10' and sys_platform == 'win32'
 
 # Install py-tree-sitter 0.20.0 from github.com/Akuli/py-tree-sitter-builds.
 # TODO: remove once it is released on pypi

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,10 @@ PyYAML==6.0
 # TODO: get rid of wheel files committed to this repo when my windows PR
 # to tree-sitter-languages gets released
 tree-sitter-languages==1.3.0; sys_platform != 'win32'
-tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/master/vendor/tree_sitter_languages-1.3.0-cp37-cp37m-win_amd64.whl ; python_version == '3.7' and sys_platform == 'win32'
-tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/master/vendor/tree_sitter_languages-1.3.0-cp38-cp38-win_amd64.whl ; python_version == '3.8' and sys_platform == 'win32'
-tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/master/vendor/tree_sitter_languages-1.3.0-cp39-cp39-win_amd64.whl ; python_version == '3.9' and sys_platform == 'win32'
-tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/master/vendor/tree_sitter_languages-1.3.0-cp310-cp310-win_amd64.whl ; python_version == '3.10' and sys_platform == 'win32'
+tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/64dd37a1ff0826eab6b8c394d227694a2b1b8ca8/vendor/tree_sitter_languages-1.3.0-cp37-cp37m-win_amd64.whl ; python_version == '3.7' and sys_platform == 'win32'
+tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/64dd37a1ff0826eab6b8c394d227694a2b1b8ca8/vendor/tree_sitter_languages-1.3.0-cp38-cp38-win_amd64.whl ; python_version == '3.8' and sys_platform == 'win32'
+tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/64dd37a1ff0826eab6b8c394d227694a2b1b8ca8/vendor/tree_sitter_languages-1.3.0-cp39-cp39-win_amd64.whl ; python_version == '3.9' and sys_platform == 'win32'
+tree-sitter-languages @ https://github.com/Akuli/porcupine/raw/64dd37a1ff0826eab6b8c394d227694a2b1b8ca8/vendor/tree_sitter_languages-1.3.0-cp310-cp310-win_amd64.whl ; python_version == '3.10' and sys_platform == 'win32'
 
 # Install py-tree-sitter 0.20.0 from github.com/Akuli/py-tree-sitter-builds.
 # TODO: remove once it is released on pypi


### PR DESCRIPTION
Not ideal, but there's no way to say "this commit" in a requirements.txt file. The whole thing is a "temporary" hack anyway :)