### PR TITLE
tree-sitter highlighting for C

### DIFF
--- a/porcupine/default_filetypes.toml
+++ b/porcupine/default_filetypes.toml
@@ -230,6 +230,8 @@ autoindent_regexes = {indent = '.*:'}
 [C]
 filename_patterns = ["*.c", "*.h"]
 pygments_lexer = "pygments.lexers.CLexer"
+syntax_highlighter = "tree_sitter"
+tree_sitter_language_name = "c"
 comment_prefix = '//'
 # Press alt+enter instead of enter to avoid indent after 'case foo:'
 autoindent_regexes = {dedent = '(return( .+)?|break|continue);', indent = '(case .+|default):'}

--- a/porcupine/plugins/highlight/tree-sitter-token-mappings/c.yml
+++ b/porcupine/plugins/highlight/tree-sitter-token-mappings/c.yml
@@ -15,7 +15,7 @@ queries:
   preproc_function_def: |
     (preproc_function_def
       ("#define") @Token.Keyword
-      name: (_) @Token.Name.Function  # close enough lol
+      name: (_) @Token.Name.Function
       parameters: (_) @recurse
       # Recursing into the value wouldn't help, it parses into a string (if it isn't missing)
     )
@@ -49,7 +49,7 @@ token_mapping:
     '#undef': Token.Keyword
 
   # Applies to: typedef/struct/union/enum names when defining and using them
-  type_identifier: Token.Name.Function
+  type_identifier: Token.Name.Class
 
   string_literal: Token.Literal.String
   char_literal: Token.Literal.String.Char

--- a/porcupine/plugins/highlight/tree-sitter-token-mappings/c.yml
+++ b/porcupine/plugins/highlight/tree-sitter-token-mappings/c.yml
@@ -1,5 +1,5 @@
 queries:
-  # Highlight #include, #define etc as decorator, because decorators have a nice color in many themes.
+  # Highlight #include, #define etc as keywords, because they behave like keywords.
   preproc_include: |
     (preproc_include
       ("#include") @Token.Keyword
@@ -10,14 +10,14 @@ queries:
     (preproc_def
       ("#define") @Token.Keyword
       name: (_) @Token.Name.Function  # close enough lol
-      # Recursing into the value wouldn't help, it parses as text (if it isn't missing)
+      # Recursing into the value wouldn't help, it parses into a string (if it isn't missing)
     )
   preproc_function_def: |
     (preproc_function_def
       ("#define") @Token.Keyword
       name: (_) @Token.Name.Function  # close enough lol
       parameters: (_) @recurse
-      # Recursing into the value wouldn't help, it parses as text (if it isn't missing)
+      # Recursing into the value wouldn't help, it parses into a string (if it isn't missing)
     )
 
 dont_recurse_inside:
@@ -27,11 +27,17 @@ dont_recurse_inside:
 token_mapping:
   '#if': Token.Keyword
   '#ifdef': Token.Keyword
+  '#ifndef': Token.Keyword
   '#elif': Token.Keyword
   '#else': Token.Keyword
   '#endif': Token.Keyword
+  '#error': Token.Keyword
+
+  # Only highlight known preprocessor directives.
+  # This way you immediately know if you try something like #ifnotdef
   preproc_directive:
     '#pragma': Token.Keyword
+    '#undef': Token.Keyword
 
   # Applies to: typedef/struct/union/enum names when defining and using them
   type_identifier: Token.Name.Function

--- a/porcupine/plugins/highlight/tree-sitter-token-mappings/c.yml
+++ b/porcupine/plugins/highlight/tree-sitter-token-mappings/c.yml
@@ -1,0 +1,63 @@
+queries:
+  # Highlight #include, #define etc as decorator, because decorators have a nice color in many themes.
+  preproc_include: |
+    (preproc_include
+      ("#include") @Token.Keyword
+      # Always highlight included file name (<foo.h> or "foo.h") as string
+      path: (_) @Token.Literal.String
+    )
+  preproc_def: |
+    (preproc_def
+      ("#define") @Token.Keyword
+      name: (_) @Token.Name.Function  # close enough lol
+      # Recursing into the value wouldn't help, it parses as text (if it isn't missing)
+    )
+  preproc_function_def: |
+    (preproc_function_def
+      ("#define") @Token.Keyword
+      name: (_) @Token.Name.Function  # close enough lol
+      parameters: (_) @recurse
+      # Recursing into the value wouldn't help, it parses as text (if it isn't missing)
+    )
+
+dont_recurse_inside:
+  - string_literal
+  - char_literal
+
+token_mapping:
+  '#if': Token.Keyword
+  '#ifdef': Token.Keyword
+  '#elif': Token.Keyword
+  '#else': Token.Keyword
+  '#endif': Token.Keyword
+  preproc_directive:
+    '#pragma': Token.Keyword
+
+  # Applies to: typedef/struct/union/enum names when defining and using them
+  type_identifier: Token.Name.Function
+
+  string_literal: Token.Literal.String
+  char_literal: Token.Literal.String.Char
+
+  primitive_type: Token.Keyword
+  struct: Token.Keyword
+  enum: Token.Keyword
+  union: Token.Keyword
+  static: Token.Keyword
+  if: Token.Keyword
+  else: Token.Keyword
+  while: Token.Keyword
+  for: Token.Keyword
+  break: Token.Keyword
+  return: Token.Keyword
+  const: Token.Keyword
+  switch: Token.Keyword
+  case: Token.Keyword
+  default: Token.Keyword
+  comment: Token.Comment
+  inline: Token.Keyword
+  typedef: Token.Keyword
+
+  'null': Token.Name.Builtin
+  'true': Token.Name.Builtin
+  'false': Token.Name.Builtin

--- a/porcupine/plugins/highlight/tree-sitter-token-mappings/c.yml
+++ b/porcupine/plugins/highlight/tree-sitter-token-mappings/c.yml
@@ -54,26 +54,38 @@ token_mapping:
   string_literal: Token.Literal.String
   char_literal: Token.Literal.String.Char
 
-  primitive_type: Token.Keyword
-  struct: Token.Keyword
-  enum: Token.Keyword
-  union: Token.Keyword
-  static: Token.Keyword
-  if: Token.Keyword
-  else: Token.Keyword
-  while: Token.Keyword
-  for: Token.Keyword
-  break: Token.Keyword
-  return: Token.Keyword
-  const: Token.Keyword
-  switch: Token.Keyword
-  case: Token.Keyword
-  default: Token.Keyword
   comment: Token.Comment
+  primitive_type: Token.Keyword
+
+  # "auto" intentionally missing, it's the default and therefore useless to write explicitly.
+  # This is different from "auto" in C++.
+  break: Token.Keyword
+  case: Token.Keyword
+  const: Token.Keyword
+  continue: Token.Keyword
+  default: Token.Keyword
+  do: Token.Keyword
+  else: Token.Keyword
+  enum: Token.Keyword
+  extern: Token.Keyword
+  for: Token.Keyword
+  goto: Token.Keyword
+  if: Token.Keyword
   inline: Token.Keyword
-  typedef: Token.Keyword
-  short: Token.Keyword
   long: Token.Keyword
+  register: Token.Keyword  # I have never used this
+  return: Token.Keyword
+  short: Token.Keyword
+  signed: Token.Keyword
+  sizeof: Token.Keyword
+  static: Token.Keyword
+  struct: Token.Keyword
+  switch: Token.Keyword
+  typedef: Token.Keyword
+  union: Token.Keyword
+  unsigned: Token.Keyword
+  volatile: Token.Keyword
+  while: Token.Keyword
 
   'null': Token.Name.Builtin
   'true': Token.Name.Builtin

--- a/porcupine/plugins/highlight/tree-sitter-token-mappings/c.yml
+++ b/porcupine/plugins/highlight/tree-sitter-token-mappings/c.yml
@@ -72,6 +72,8 @@ token_mapping:
   comment: Token.Comment
   inline: Token.Keyword
   typedef: Token.Keyword
+  short: Token.Keyword
+  long: Token.Keyword
 
   'null': Token.Name.Builtin
   'true': Token.Name.Builtin

--- a/porcupine/plugins/highlight/tree-sitter-token-mappings/c.yml
+++ b/porcupine/plugins/highlight/tree-sitter-token-mappings/c.yml
@@ -20,6 +20,15 @@ queries:
       # Recursing into the value wouldn't help, it parses into a string (if it isn't missing)
     )
 
+  # Highlight function names when defining a function.
+  function_declarator: |
+    (function_declarator
+      # This query doesn't apply when the function isn't just a name:   int (*foo)();
+      # In those cases we want to highlight each part of the function recursively.
+      declarator: (identifier) @Token.Name.Function
+      parameters: (_) @recurse
+    )
+
 dont_recurse_inside:
   - string_literal
   - char_literal

--- a/porcupine/plugins/highlight/tree-sitter-token-mappings/c.yml
+++ b/porcupine/plugins/highlight/tree-sitter-token-mappings/c.yml
@@ -55,6 +55,7 @@ token_mapping:
   char_literal: Token.Literal.String.Char
 
   comment: Token.Comment
+  number_literal: Token.Literal.Number
   primitive_type: Token.Keyword
 
   # "auto" intentionally missing, it's the default and therefore useless to write explicitly.

--- a/porcupine/plugins/highlight/tree-sitter-token-mappings/python.yml
+++ b/porcupine/plugins/highlight/tree-sitter-token-mappings/python.yml
@@ -30,7 +30,7 @@ queries:
   class_definition: |
     (class_definition
       ("class") @Token.Keyword
-      name: (identifier) @Token.Name.Function  # close enough lol
+      name: (identifier) @Token.Name.Class
       superclasses: (argument_list)? @recurse
       (":") @Token.Punctuation
       (comment)? @Token.Comment

--- a/porcupine/plugins/highlight/tree-sitter-token-mappings/python.yml
+++ b/porcupine/plugins/highlight/tree-sitter-token-mappings/python.yml
@@ -30,7 +30,7 @@ queries:
   class_definition: |
     (class_definition
       ("class") @Token.Keyword
-      name: (identifier) @Token.Name.Function
+      name: (identifier) @Token.Name.Function  # close enough lol
       superclasses: (argument_list)? @recurse
       (":") @Token.Punctuation
       (comment)? @Token.Comment

--- a/porcupine/plugins/highlight/tree_sitter_highlighter.py
+++ b/porcupine/plugins/highlight/tree_sitter_highlighter.py
@@ -81,7 +81,7 @@ def _strip_comments(query: str) -> str:
     # Otherwise ignore everything after '#' on the same line.
     # If the query contains an odd number of " (excluding comments), don't remove the last one.
     parts = re.findall(r'"[^"]*"|"|#.*|[^#"]+', query)
-    return ''.join(p for p in parts if not p.startswith('#'))
+    return "".join(p for p in parts if not p.startswith("#"))
 
 
 class TreeSitterHighlighter(BaseHighlighter):

--- a/porcupine/plugins/highlight/tree_sitter_highlighter.py
+++ b/porcupine/plugins/highlight/tree_sitter_highlighter.py
@@ -76,8 +76,12 @@ class YmlConfig:
     queries: Dict[str, str] = dataclasses.field(default_factory=dict)
 
 
-def _strip_comments(tree_sitter_query: str) -> str:
-    return re.sub(r"#.*", "", tree_sitter_query)
+def _strip_comments(query: str) -> str:
+    # Ignore '#' between double quotes.
+    # Otherwise ignore everything after '#' on the same line.
+    # If the query contains an odd number of " (excluding comments), don't remove the last one.
+    parts = re.findall(r'"[^"]*"|"|#.*|[^#"]+', query)
+    return ''.join(p for p in parts if not p.startswith('#'))
 
 
 class TreeSitterHighlighter(BaseHighlighter):


### PR DESCRIPTION
Important/useful for a couple reasons:
- C files are often huge, so efficient highlighting matters
- There are known bugs with the pygments highlighter: #1038
- Pygments highlights `#include`, `#define` etc as comments which is just super dumb