### PR TITLE
Run plugin: add memory limit

### DIFF
--- a/porcupine/plugins/run/__init__.py
+++ b/porcupine/plugins/run/__init__.py
@@ -8,10 +8,11 @@ import sys
 import tkinter
 from functools import partial
 from tkinter import messagebox
-from typing import List
+from typing import List, Optional
 
 from porcupine import get_main_window, get_tab_manager, menubar, tabs, utils
 from porcupine.plugins import python_venv
+from porcupine.settings import global_settings
 
 from . import common, dialog, history, no_terminal, terminal
 
@@ -76,6 +77,11 @@ def on_new_filetab(tab: tabs.FileTab) -> None:
 
 
 def setup() -> None:
+    # Memory limit affects all commands, so that you can "set it and forget it".
+    # If you choose to run a different command, it won't reset annoyingly.
+    global_settings.add_option("run_mem_limit_enabled", default=False)
+    global_settings.add_option("run_mem_limit_value", default=1000*1000*1000)
+
     get_tab_manager().add_filetab_callback(on_new_filetab)
 
     menubar.add_filetab_command(

--- a/porcupine/plugins/run/history.py
+++ b/porcupine/plugins/run/history.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import dataclasses
 import json
+import logging
 import sys
 from pathlib import Path
 from typing import Optional
@@ -12,6 +13,9 @@ import dacite
 from porcupine import dirs
 
 from . import common
+
+
+_log = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass

--- a/porcupine/plugins/run/no_terminal.py
+++ b/porcupine/plugins/run/no_terminal.py
@@ -98,6 +98,10 @@ class Executor:
     def _thread_target(self, command: str, env: dict[str, str]) -> None:
         self._queue.put(("info", command + "\n"))
 
+        popen_kwargs = utils.subprocess_kwargs.copy()
+        if sys.platform != "win32":
+            popen_kwargs["preexec_fn"] = common.create_memory_limit_callback()
+
         try:
             self._shell_process = subprocess.Popen(
                 command,
@@ -106,7 +110,7 @@ class Executor:
                 stderr=subprocess.STDOUT,
                 shell=True,
                 env=env,
-                **utils.subprocess_kwargs,
+                **popen_kwargs,
             )
         except OSError as e:
             self._queue.put(("error", f"{type(e).__name__}: {e}\n"))

--- a/porcupine/plugins/run/terminal.py
+++ b/porcupine/plugins/run/terminal.py
@@ -34,6 +34,8 @@ def _run_in_windows_cmd(command: str, cwd: Path, env: dict[str, str]) -> None:
         # new command prompt i found and it works :) we need cmd
         # because start is built in to cmd (lol)
         real_command = ["cmd", "/c", "start"] + real_command
+
+    # no memory limit, don't know how to get that to work on windows
     subprocess.Popen(real_command, env=env)
 
 
@@ -53,7 +55,11 @@ def _run_in_macos_terminal_app(command: str, cwd: Path, env: dict[str, str]) -> 
         )
 
     os.chmod(file.name, 0o755)
-    subprocess.Popen(["open", "-a", "Terminal.app", file.name], env=env)
+    subprocess.Popen(
+        ["open", "-a", "Terminal.app", file.name],
+        env=env,
+        preexec_fn=common.create_memory_limit_callback(),
+    )
     # the terminal might be still opening when we get here, that's why
     # the file deletes itself
     # right now the file removes itself before it runs the actual command so
@@ -118,7 +124,11 @@ def _run_in_x11_like_terminal(command: str, cwd: Path, env: dict[str, str]) -> N
 
     real_command = [str(run_script), str(cwd), command]
     real_command.extend(map(str, command))
-    subprocess.Popen([terminal, "-e", " ".join(map(shlex.quote, real_command))], env=env)
+    subprocess.Popen(
+        [terminal, "-e", " ".join(map(shlex.quote, real_command))],
+        env=env,
+        preexec_fn=common.create_memory_limit_callback(),
+    )
 
 
 # this figures out which terminal to use every time the user wants to run


### PR DESCRIPTION
On linux, it's annoying when my dumb program allocates so much memory that the entire computer freezes. This is because linux decides that it's a good idea to use swap for more memory. Swap basically means using the hard drive as if it was RAM, and that's really really slow.

To help with this, add a setting that limits how much memory the program can allocate. The setting shows up in the run dialog, but it's saved to Porcupine's settings so that it won't change if you run a different command.