### PR TITLE
Run plugin: Make filename matching case-insensitive

### DIFF
--- a/porcupine/plugins/run/no_terminal.py
+++ b/porcupine/plugins/run/no_terminal.py
@@ -44,7 +44,7 @@ filename_regex_parts = [
     # blah blah: some_function (filename.c:123)
     r"\(([^\n():]+):([0-9]+)\)",
 ]
-filename_regex = "|".join(r"(?:" + part + r")" for part in filename_regex_parts)
+filename_regex = "(?i)" + "|".join(r"(?:" + part + r")" for part in filename_regex_parts)
 
 
 def open_file_with_line_number(path: Path, lineno: int) -> None:


### PR DESCRIPTION
I'm developing yet another toy programming language, and it is outputting strings like this:

```
compiler error in file "examples/hello.jou", line 5: function "putchar" takes 1 argument, but it was called with 0 arguments
```

With this PR, `file "examples/hello.jou", line 5` becomes clickable.