### PR TITLE
Add a desktop launcher creating plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ To run porcupine later, you need to activate the virtualenv before running it:
     source porcupine-venv/bin/activate
     porcu
 
-You can uninstall Porcupine by deleting `porcupine-venv`.
+Alternatively, you can ask Porcupine to create a double-clickable launcher on your desktop:
+
+    source porcupine-venv/bin/activate
+    porcu --create-desktop-launcher
+
+You can uninstall Porcupine by deleting `porcupine-venv` and the launcher on desktop.
 
 ### Other Linux distributions
 
@@ -84,7 +89,12 @@ To run porcupine later, you need to activate the virtualenv before running it:
     source porcupine-venv/bin/activate
     porcu
 
-You can uninstall Porcupine by deleting `porcupine-venv`.
+Alternatively, you can ask Porcupine to create a double-clickable launcher on your desktop:
+
+    source porcupine-venv/bin/activate
+    porcu --create-desktop-launcher
+
+You can uninstall Porcupine by deleting `porcupine-venv` and the launcher on desktop.
 
 ### MacOS
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ Open a terminal and run these commands:
     python3 -m pip install https://github.com/Akuli/porcupine/archive/v2022.11.25.zip
     porcu
 
-If you want to leave Porcupine running and use the same terminal for something else,
-you can use `porcu&` instead of `porcu`.
 To run porcupine later, you need to activate the virtualenv before running it:
 
     source porcupine-venv/bin/activate
@@ -82,8 +80,6 @@ Then run these commands:
     python3 -m pip install https://github.com/Akuli/porcupine/archive/v2022.11.25.zip
     porcu
 
-If you want to leave Porcupine running and use the same terminal for something else,
-you can use `porcu&` instead of `porcu`.
 To run porcupine later, you need to activate the virtualenv before running it:
 
     source porcupine-venv/bin/activate

--- a/porcupine/plugins/desktop_launcher.py
+++ b/porcupine/plugins/desktop_launcher.py
@@ -43,7 +43,7 @@ class CreateLauncherAction(argparse.Action):
         with launcher_path.open("w") as file:
             file.write("[Desktop Entry]\n")
             file.write("Name=Porcupine\n")
-            file.write(f"Exec={command}\n")
+            file.write(f"Exec=bash -c {shlex.quote(command)}\n")
             file.write("Terminal=false\n")
             file.write("Type=Application\n")
             file.write(f"Icon={images.images_dir}/logo-200x200.gif\n")

--- a/porcupine/plugins/desktop_launcher.py
+++ b/porcupine/plugins/desktop_launcher.py
@@ -22,7 +22,8 @@ class CreateLauncherAction(argparse.Action):
         super().__init__(*args, **kwargs)
 
     def __call__(self, *args: object) -> None:
-        if sys.platform != "linux":
+        # str() needed to work around mypy bugginess
+        if str(sys.platform) == "linux":
             sys.exit("Error: --create-desktop-launcher can only be used on Linux")
 
         venv = os.environ.get("VIRTUAL_ENV")

--- a/porcupine/plugins/desktop_launcher.py
+++ b/porcupine/plugins/desktop_launcher.py
@@ -7,12 +7,13 @@ Currently --create-desktop-launcher works only on Linux.
 """
 
 import argparse
-import sys
-import shlex
 import os
-from pathlib import Path
-from porcupine import images
+import shlex
 import subprocess
+import sys
+from pathlib import Path
+
+from porcupine import images
 
 
 class CreateLauncherAction(argparse.Action):
@@ -25,11 +26,13 @@ class CreateLauncherAction(argparse.Action):
 
         venv = os.environ.get("VIRTUAL_ENV")
         if not venv:
-            sys.exit("Error: --create-desktop-launcher can only be used when Porcupine is installed into a virtualenv")
+            sys.exit(
+                "Error: --create-desktop-launcher can only be used when Porcupine is installed into a virtualenv"
+            )
 
         # launcher_path is basically ~/Desktop/Porcupine.desktop.
         # But if your OS is not in english it could be e.g. ~/Työpöytä/Porcupine.desktop.
-        output = subprocess.check_output(['xdg-user-dir', 'DESKTOP'], text=True)
+        output = subprocess.check_output(["xdg-user-dir", "DESKTOP"], text=True)
         launcher_path = Path(output.strip("\n")) / "Porcupine.desktop"
 
         activate_path = Path(venv) / "bin" / "activate"
@@ -55,8 +58,11 @@ class CreateLauncherAction(argparse.Action):
 
 def setup_argument_parser(parser: argparse.ArgumentParser) -> None:
     if sys.platform == "linux":
-        parser.add_argument("--create-desktop-launcher", action=CreateLauncherAction,
-        help="create a double-clickable Porcupine launcher icon to desktop (Linux only)")
+        parser.add_argument(
+            "--create-desktop-launcher",
+            action=CreateLauncherAction,
+            help="create a double-clickable Porcupine launcher icon to desktop (Linux only)",
+        )
 
 
 def setup() -> None:

--- a/porcupine/plugins/desktop_launcher.py
+++ b/porcupine/plugins/desktop_launcher.py
@@ -1,0 +1,63 @@
+"""Adds a command-line option "--create-desktop-launcher" to Porcupine.
+
+When you run "porcu --create-desktop-launcher", it creates a double-clickable
+launcher to the user's desktop. The launcher runs Porcupine.
+
+Currently --create-desktop-launcher works only on Linux.
+"""
+
+import argparse
+import sys
+import shlex
+import os
+from pathlib import Path
+from porcupine import images
+import subprocess
+
+
+class CreateLauncherAction(argparse.Action):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, nargs=0, **kwargs)
+
+    def __call__(self, *args):
+        if sys.platform != "linux":
+            sys.exit("Error: --create-desktop-launcher can only be used on Linux")
+
+        venv = os.environ.get("VIRTUAL_ENV")
+        if not venv:
+            sys.exit("Error: --create-desktop-launcher can only be used when Porcupine is installed into a virtualenv")
+
+        # launcher_path is basically ~/Desktop/Porcupine.desktop.
+        # But if your OS is not in english it could be e.g. ~/Työpöytä/Porcupine.desktop.
+        output = subprocess.check_output(['xdg-user-dir', 'DESKTOP'], text=True)
+        launcher_path = Path(output.strip("\n")) / "Porcupine.desktop"
+
+        activate_path = Path(venv) / "bin" / "activate"
+        assert activate_path.is_file()
+
+        command = f"source {shlex.quote(str(activate_path))} && porcu"
+
+        with launcher_path.open("w") as file:
+            file.write("[Desktop Entry]\n")
+            file.write("Name=Porcupine\n")
+            file.write(f"Exec={command}\n")
+            file.write("Terminal=false\n")
+            file.write("Type=Application\n")
+            file.write(f"Icon={images.images_dir}/logo-200x200.gif\n")
+
+        # do what is basically "chmod +x": https://stackoverflow.com/a/12792002
+        execute_permissions = 0o111
+        launcher_path.chmod(launcher_path.stat().st_mode | execute_permissions)
+
+        print(f"Created {launcher_path}")
+        sys.exit(0)
+
+
+def setup_argument_parser(parser: argparse.ArgumentParser) -> None:
+    if sys.platform == "linux":
+        parser.add_argument("--create-desktop-launcher", action=CreateLauncherAction,
+        help="create a double-clickable Porcupine launcher icon to desktop (Linux only)")
+
+
+def setup() -> None:
+    pass


### PR DESCRIPTION
Installing Porcupine is a bit of a mess on Linux. To run it, according to README, you need two commands:

```
source porcupine-venv/bin/activate
porcu
```

This PR adds a way to create a launcher to your desktop that you can simply double-click.