### PR TITLE
Fix release script so it keeps version in pyproject.toml up to date

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "porcupine"
-version = "2022.08.27"
+version = "2023.03.11"
 description = "A decent editor written in tkinter"
 authors = [{name = "Akuli", email = "akuviljanen17@gmail.com"}]
 readme = "README.md"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -43,7 +43,9 @@ def main():
     replace_in_file(Path("CHANGELOG.md"), "Unreleased", TAG_FORMAT % new_info)
     replace_in_file(Path("porcupine/__init__.py"), repr(old_info), repr(new_info))
     replace_in_file(Path("README.md"), TAG_FORMAT % old_info, TAG_FORMAT % new_info)
-    replace_in_file(Path("pyproject.toml"), TAG_FORMAT.lstrip("v") % old_info, TAG_FORMAT.lstrip("v") % new_info)
+    replace_in_file(
+        Path("pyproject.toml"), TAG_FORMAT.lstrip("v") % old_info, TAG_FORMAT.lstrip("v") % new_info
+    )
     subprocess.check_call(["git", "add", "porcupine/__init__.py", "README.md", "CHANGELOG.md"])
     subprocess.check_call(["git", "commit", "-m", f"Version {TAG_FORMAT % new_info}"])
     subprocess.check_call(["git", "tag", TAG_FORMAT % new_info])

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -43,6 +43,7 @@ def main():
     replace_in_file(Path("CHANGELOG.md"), "Unreleased", TAG_FORMAT % new_info)
     replace_in_file(Path("porcupine/__init__.py"), repr(old_info), repr(new_info))
     replace_in_file(Path("README.md"), TAG_FORMAT % old_info, TAG_FORMAT % new_info)
+    replace_in_file(Path("pyproject.toml"), TAG_FORMAT % old_info, TAG_FORMAT % new_info)
     subprocess.check_call(["git", "add", "porcupine/__init__.py", "README.md", "CHANGELOG.md"])
     subprocess.check_call(["git", "commit", "-m", f"Version {TAG_FORMAT % new_info}"])
     subprocess.check_call(["git", "tag", TAG_FORMAT % new_info])

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -43,7 +43,7 @@ def main():
     replace_in_file(Path("CHANGELOG.md"), "Unreleased", TAG_FORMAT % new_info)
     replace_in_file(Path("porcupine/__init__.py"), repr(old_info), repr(new_info))
     replace_in_file(Path("README.md"), TAG_FORMAT % old_info, TAG_FORMAT % new_info)
-    replace_in_file(Path("pyproject.toml"), TAG_FORMAT % old_info, TAG_FORMAT % new_info)
+    replace_in_file(Path("pyproject.toml"), TAG_FORMAT.lstrip("v") % old_info, TAG_FORMAT.lstrip("v") % new_info)
     subprocess.check_call(["git", "add", "porcupine/__init__.py", "README.md", "CHANGELOG.md"])
     subprocess.check_call(["git", "commit", "-m", f"Version {TAG_FORMAT % new_info}"])
     subprocess.check_call(["git", "tag", TAG_FORMAT % new_info])


### PR DESCRIPTION
Was wondering why `pip install` showed the wrong version of Porcupine when installing the version that I just released minutes ago.