### PR TITLE
Do not allow pastebins to return http:// URLs

### DIFF
--- a/porcupine/plugins/pastebin.py
+++ b/porcupine/plugins/pastebin.py
@@ -278,7 +278,7 @@ def pasting_done_callback(
     please_wait_window.destroy()
 
     if success:
-        if result.startswith(("http://", "https://")):
+        if result.startswith("https://"):
             log.info("pasting succeeded")
             dialog = SuccessDialog(url=result)
             dialog.title("Pasting Succeeded")


### PR DESCRIPTION
Nowadays `http://` URLs are considered bad. There's no need to support them in Porcupine's pastebin plugin, because neither of the two pastebins we use gives them.