### PR TITLE
Forward files list from Porcupine.desktop

### DIFF
--- a/porcupine/plugins/desktop_menu.py
+++ b/porcupine/plugins/desktop_menu.py
@@ -41,8 +41,10 @@ def install_desktop_file() -> None:
         file.write("GenericName=Text Editor\n")
         # Must activate the venv, otherwise various things don't work
         # (e.g. os.environ.get("VIRTUAL_ENV") in this plugin)
-        bash_command = f"source {shlex.quote(str(activate_path))} && porcu %F"
-        file.write(f"Exec=bash -c {shlex.quote(bash_command)}\n")
+        # %F is a list of file names that are already quoted, so we cannot place that inside quotes.
+        # Instead we need https://unix.stackexchange.com/a/144519
+        bash_command = f'source {shlex.quote(str(activate_path))} && porcu "$@"'
+        file.write(f"Exec=bash -c {shlex.quote(bash_command)} bash %F\n")
         file.write("Terminal=false\n")
         file.write("Type=Application\n")
         file.write("Categories=TextEditor;Development;\n")

--- a/porcupine/plugins/desktop_menu.py
+++ b/porcupine/plugins/desktop_menu.py
@@ -41,7 +41,7 @@ def install_desktop_file() -> None:
         file.write("GenericName=Text Editor\n")
         # Must activate the venv, otherwise various things don't work
         # (e.g. os.environ.get("VIRTUAL_ENV") in this plugin)
-        bash_command = f"source {shlex.quote(str(activate_path))} && porcu"
+        bash_command = f"source {shlex.quote(str(activate_path))} && porcu %F"
         file.write(f"Exec=bash -c {shlex.quote(bash_command)}\n")
         file.write("Terminal=false\n")
         file.write("Type=Application\n")


### PR DESCRIPTION
This allows files to be opened with `xdg-open`, when Porcupine is set as default app for that MIME type