### PR TITLE
Run plugin: support pygments themes that don't provide Token.Literal.String foreground color

### DIFF
--- a/porcupine/plugins/run/no_terminal.py
+++ b/porcupine/plugins/run/no_terminal.py
@@ -300,7 +300,8 @@ class NoTerminalRunner:
 
         def on_style_changed(junk: object = None) -> None:
             self.textwidget.config(
-                foreground=self.textwidget.tag_cget("Token.Literal.String", "foreground") or self.textwidget["fg"]
+                foreground=self.textwidget.tag_cget("Token.Literal.String", "foreground")
+                or self.textwidget["fg"]
             )
 
         self.textwidget.bind(

--- a/porcupine/plugins/run/no_terminal.py
+++ b/porcupine/plugins/run/no_terminal.py
@@ -300,7 +300,7 @@ class NoTerminalRunner:
 
         def on_style_changed(junk: object = None) -> None:
             self.textwidget.config(
-                foreground=self.textwidget.tag_cget("Token.Literal.String", "foreground")
+                foreground=self.textwidget.tag_cget("Token.Literal.String", "foreground") or self.textwidget["fg"]
             )
 
         self.textwidget.bind(

--- a/porcupine/plugins/run/no_terminal.py
+++ b/porcupine/plugins/run/no_terminal.py
@@ -300,8 +300,10 @@ class NoTerminalRunner:
 
         def on_style_changed(junk: object = None) -> None:
             self.textwidget.config(
-                foreground=(self.textwidget.tag_cget("Token.Literal.String", "foreground")
-                or self.textwidget["fg"])
+                foreground=(
+                    self.textwidget.tag_cget("Token.Literal.String", "foreground")
+                    or self.textwidget["fg"]
+                )
             )
 
         self.textwidget.bind(

--- a/porcupine/plugins/run/no_terminal.py
+++ b/porcupine/plugins/run/no_terminal.py
@@ -300,8 +300,8 @@ class NoTerminalRunner:
 
         def on_style_changed(junk: object = None) -> None:
             self.textwidget.config(
-                foreground=self.textwidget.tag_cget("Token.Literal.String", "foreground")
-                or self.textwidget["fg"]
+                foreground=(self.textwidget.tag_cget("Token.Literal.String", "foreground")
+                or self.textwidget["fg"])
             )
 
         self.textwidget.bind(


### PR DESCRIPTION
I noticed that switching the output to the `murpy` color theme in settings caused an error. This fixes it.