### PR TITLE
Issues with dependencies when installing on Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,8 @@ env*/
 # Rope project settings
 .ropeproject
 
+# Mac stuff
+.DS_Store
 
 # other stuff i have needed to add
 .pytest_cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,5 @@ send2trash>=1.8.0,<2.0.0
 psutil>=5.8.0,<6.0.0
 PyYAML==6.0
 tree-sitter-builds==2022.8.27
+tree_sitter_languages
 sv-ttk>=2.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,10 @@ tomli==2.0.1
 send2trash>=1.8.0,<2.0.0
 psutil>=5.8.0,<6.0.0
 PyYAML==6.0
-tree-sitter-builds==2022.8.27
-tree_sitter_languages
+# tree-sitter-builds 2023.3.12 throws "ERROR: Could not find a version that satisfies the requirement tree-sitter-builds==2023.3.12 (from versions: 2022.8.27)
+# ERROR: No matching distribution found for tree-sitter-builds==2023.3.12" on Mac. 
+# Using 2022.8.27 without tree_sitter_languages throws ModuleNotFoundError.
+tree-sitter-builds==2022.8.27 ; sys_platform=="darwin"
+tree_sitter_languages ; sys_platform=="darwin"
+tree-sitter-builds==2023.3.12 ; sys_platform!="darwin"
 sv-ttk>=2.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ tomli==2.0.1
 send2trash>=1.8.0,<2.0.0
 psutil>=5.8.0,<6.0.0
 PyYAML==6.0
-tree-sitter-builds==2023.3.12
+tree-sitter-builds==2022.8.27
 sv-ttk>=2.4.5


### PR DESCRIPTION
With the current build, it was not possible to install Porcupine on Mac.

After cloning:

```
git clone https://github.com/ThePhilgrim/porcupine-phil
Cloning into 'porcupine-phil'...
remote: Enumerating objects: 12207, done.
remote: Counting objects: 100% (563/563), done.
remote: Compressing objects: 100% (270/270), done.
remote: Total 12207 (delta 339), reused 488 (delta 282), pack-reused 11644
Receiving objects: 100% (12207/12207), 13.94 MiB | 3.00 MiB/s, done.
Resolving deltas: 100% (9253/9253), done.
❯ cd porcupine-phil
❯ clear
❯ python3 -m venv env
❯ source env/bin/activate
❯ pip install -r requirements.txt
Collecting platformdirs<4.0.0,>=3.0.0
  Using cached platformdirs-3.8.0-py3-none-any.whl (16 kB)
Collecting Pygments==2.12.0
  Using cached Pygments-2.12.0-py3-none-any.whl (1.1 MB)
Collecting toposort>=1.5
  Using cached toposort-1.10-py3-none-any.whl (8.5 kB)
Collecting colorama>=0.2.5
  Using cached colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Collecting sansio-lsp-client<0.11.0,>=0.10.0
  Using cached sansio_lsp_client-0.10.0-py3-none-any.whl (14 kB)
Collecting python-language-server[pyflakes,rope]<1.0.0,>=0.36.2
  Using cached python_language_server-0.36.2-py2.py3-none-any.whl (51 kB)
Collecting black>=21.5b2
  Using cached black-23.3.0-cp311-cp311-macosx_10_16_universal2.whl (2.6 MB)
Collecting isort>=5.10
  Using cached isort-5.12.0-py3-none-any.whl (91 kB)
Collecting typing_extensions
  Using cached typing_extensions-4.7.1-py3-none-any.whl (33 kB)
Collecting dacite<2.0.0,>=1.5.1
  Using cached dacite-1.8.1-py3-none-any.whl (14 kB)
Collecting tomli==2.0.1
  Using cached tomli-2.0.1-py3-none-any.whl (12 kB)
Collecting send2trash<2.0.0,>=1.8.0
  Using cached Send2Trash-1.8.2-py3-none-any.whl (18 kB)
Collecting psutil<6.0.0,>=5.8.0
  Using cached psutil-5.9.5-cp38-abi3-macosx_11_0_arm64.whl (246 kB)
Collecting PyYAML==6.0
  Using cached PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl (167 kB)
ERROR: Could not find a version that satisfies the requirement tree-sitter-builds==2023.3.12 (from versions: 2022.8.27)
ERROR: No matching distribution found for tree-sitter-builds==2023.3.12
```

After commit 1 (changing `tree-sitter-builds` to 2022.8.27). I removed the venv and remade it to simulate a new installation of the dependencies:

```
❯ python3 -m venv env
❯ source env/bin/activate
❯ pip install -r requirements.txt
Collecting platformdirs<4.0.0,>=3.0.0
  Using cached platformdirs-3.8.0-py3-none-any.whl (16 kB)
Collecting Pygments==2.12.0
  Using cached Pygments-2.12.0-py3-none-any.whl (1.1 MB)
Collecting toposort>=1.5
  Using cached toposort-1.10-py3-none-any.whl (8.5 kB)
Collecting colorama>=0.2.5
  Using cached colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Collecting sansio-lsp-client<0.11.0,>=0.10.0
  Using cached sansio_lsp_client-0.10.0-py3-none-any.whl (14 kB)
Collecting python-language-server[pyflakes,rope]<1.0.0,>=0.36.2
  Using cached python_language_server-0.36.2-py2.py3-none-any.whl (51 kB)
Collecting black>=21.5b2
  Using cached black-23.3.0-cp311-cp311-macosx_10_16_universal2.whl (2.6 MB)
Collecting isort>=5.10
  Using cached isort-5.12.0-py3-none-any.whl (91 kB)
Collecting typing_extensions
  Using cached typing_extensions-4.7.1-py3-none-any.whl (33 kB)
Collecting dacite<2.0.0,>=1.5.1
  Using cached dacite-1.8.1-py3-none-any.whl (14 kB)
Collecting tomli==2.0.1
  Using cached tomli-2.0.1-py3-none-any.whl (12 kB)
Collecting send2trash<2.0.0,>=1.8.0
  Using cached Send2Trash-1.8.2-py3-none-any.whl (18 kB)
Collecting psutil<6.0.0,>=5.8.0
  Using cached psutil-5.9.5-cp38-abi3-macosx_11_0_arm64.whl (246 kB)
Collecting PyYAML==6.0
  Using cached PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl (167 kB)
Collecting tree-sitter-builds==2022.8.27
  Using cached tree_sitter_builds-2022.8.27-cp311-cp311-macosx_11_0_arm64.whl (106 kB)
Collecting sv-ttk>=2.4.5
  Using cached sv_ttk-2.5.2-py3-none-any.whl (25 kB)
Collecting pydantic<2.0.0,>=1.7.3
  Using cached pydantic-1.10.10-cp311-cp311-macosx_11_0_arm64.whl (2.5 MB)
Collecting jedi<0.18.0,>=0.17.2
  Using cached jedi-0.17.2-py2.py3-none-any.whl (1.4 MB)
Collecting python-jsonrpc-server>=0.4.0
  Using cached python_jsonrpc_server-0.4.0-py3-none-any.whl (8.9 kB)
Collecting pluggy
  Using cached pluggy-1.2.0-py3-none-any.whl (17 kB)
Collecting ujson>=3.0.0
  Using cached ujson-5.8.0-cp311-cp311-macosx_11_0_arm64.whl (54 kB)
Collecting pyflakes<2.3.0,>=2.2.0
  Using cached pyflakes-2.2.0-py2.py3-none-any.whl (66 kB)
Collecting rope>0.10.5
  Using cached rope-1.9.0-py3-none-any.whl (203 kB)
Collecting click>=8.0.0
  Using cached click-8.1.3-py3-none-any.whl (96 kB)
Collecting mypy-extensions>=0.4.3
  Using cached mypy_extensions-1.0.0-py3-none-any.whl (4.7 kB)
Collecting packaging>=22.0
  Using cached packaging-23.1-py3-none-any.whl (48 kB)
Collecting pathspec>=0.9.0
  Using cached pathspec-0.11.1-py3-none-any.whl (29 kB)
Collecting parso<0.8.0,>=0.7.0
  Using cached parso-0.7.1-py2.py3-none-any.whl (109 kB)
Collecting pytoolconfig[global]>=1.2.2
  Using cached pytoolconfig-1.2.5-py3-none-any.whl (16 kB)
Installing collected packages: toposort, ujson, typing_extensions, tree-sitter-builds, tomli, sv-ttk, send2trash, PyYAML, Pygments, pyflakes, psutil, pluggy, platformdirs, pathspec, parso, packaging, mypy-extensions, isort, dacite, colorama, click, pytoolconfig, python-jsonrpc-server, pydantic, jedi, black, sansio-lsp-client, python-language-server, rope
Successfully installed PyYAML-6.0 Pygments-2.12.0 black-23.3.0 click-8.1.3 colorama-0.4.6 dacite-1.8.1 isort-5.12.0 jedi-0.17.2 mypy-extensions-1.0.0 packaging-23.1 parso-0.7.1 pathspec-0.11.1 platformdirs-3.8.0 pluggy-1.2.0 psutil-5.9.5 pydantic-1.10.10 pyflakes-2.2.0 python-jsonrpc-server-0.4.0 python-language-server-0.36.2 pytoolconfig-1.2.5 rope-1.9.0 sansio-lsp-client-0.10.0 send2trash-1.8.2 sv-ttk-2.5.2 tomli-2.0.1 toposort-1.10 tree-sitter-builds-2022.8.27 typing_extensions-4.7.1 ujson-5.8.0

[notice] A new release of pip is available: 23.0.1 -> 23.1.2
[notice] To update, run: pip install --upgrade pip
❯ python3 -m porcupine
log file: /Users/phil/Library/Logs/Porcupine/2023-07-03T22-18-01.txt
porcupine.pluginloader ERROR: can't import porcupine.plugins.highlight
Traceback (most recent call last):
  File "/Users/phil/dev/porcupine-phil/porcupine/pluginloader.py", line 156, in _import_plugin
    info.module = importlib.import_module(f"porcupine.plugins.{info.name}")
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/phil/dev/porcupine-phil/porcupine/plugins/highlight/__init__.py", line 21, in <module>
    from .tree_sitter_highlighter import TreeSitterHighlighter
  File "/Users/phil/dev/porcupine-phil/porcupine/plugins/highlight/tree_sitter_highlighter.py", line 12, in <module>
    import tree_sitter_languages
ModuleNotFoundError: No module named 'tree_sitter_languages'
porcupine.plugins.drop_to_open ERROR: dragging files to Porcupine won't work because tkdnd isn't installed
```

After adding `tree-sitter-languages` to `requirements.txt` (again with new env):

```
❯ python3 -m venv env
❯ source env/bin/activate
❯ pip install -r requirements.txt
Collecting platformdirs<4.0.0,>=3.0.0
  Using cached platformdirs-3.8.0-py3-none-any.whl (16 kB)
Collecting Pygments==2.12.0
  Using cached Pygments-2.12.0-py3-none-any.whl (1.1 MB)
Collecting toposort>=1.5
  Using cached toposort-1.10-py3-none-any.whl (8.5 kB)
Collecting colorama>=0.2.5
  Using cached colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Collecting sansio-lsp-client<0.11.0,>=0.10.0
  Using cached sansio_lsp_client-0.10.0-py3-none-any.whl (14 kB)
Collecting python-language-server[pyflakes,rope]<1.0.0,>=0.36.2
  Using cached python_language_server-0.36.2-py2.py3-none-any.whl (51 kB)
Collecting black>=21.5b2
  Using cached black-23.3.0-cp311-cp311-macosx_10_16_universal2.whl (2.6 MB)
Collecting isort>=5.10
  Using cached isort-5.12.0-py3-none-any.whl (91 kB)
Collecting typing_extensions
  Using cached typing_extensions-4.7.1-py3-none-any.whl (33 kB)
Collecting dacite<2.0.0,>=1.5.1
  Using cached dacite-1.8.1-py3-none-any.whl (14 kB)
Collecting tomli==2.0.1
  Using cached tomli-2.0.1-py3-none-any.whl (12 kB)
Collecting send2trash<2.0.0,>=1.8.0
  Using cached Send2Trash-1.8.2-py3-none-any.whl (18 kB)
Collecting psutil<6.0.0,>=5.8.0
  Using cached psutil-5.9.5-cp38-abi3-macosx_11_0_arm64.whl (246 kB)
Collecting PyYAML==6.0
  Using cached PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl (167 kB)
Collecting tree-sitter-builds==2022.8.27
  Using cached tree_sitter_builds-2022.8.27-cp311-cp311-macosx_11_0_arm64.whl (106 kB)
Collecting tree_sitter_languages
  Using cached tree_sitter_languages-1.6.1-cp311-cp311-macosx_11_0_arm64.whl (5.2 MB)
Collecting sv-ttk>=2.4.5
  Using cached sv_ttk-2.5.2-py3-none-any.whl (25 kB)
Collecting pydantic<2.0.0,>=1.7.3
  Using cached pydantic-1.10.10-cp311-cp311-macosx_11_0_arm64.whl (2.5 MB)
Collecting jedi<0.18.0,>=0.17.2
  Using cached jedi-0.17.2-py2.py3-none-any.whl (1.4 MB)
Collecting python-jsonrpc-server>=0.4.0
  Using cached python_jsonrpc_server-0.4.0-py3-none-any.whl (8.9 kB)
Collecting pluggy
  Using cached pluggy-1.2.0-py3-none-any.whl (17 kB)
Collecting ujson>=3.0.0
  Using cached ujson-5.8.0-cp311-cp311-macosx_11_0_arm64.whl (54 kB)
Collecting pyflakes<2.3.0,>=2.2.0
  Using cached pyflakes-2.2.0-py2.py3-none-any.whl (66 kB)
Collecting rope>0.10.5
  Using cached rope-1.9.0-py3-none-any.whl (203 kB)
Collecting click>=8.0.0
  Using cached click-8.1.3-py3-none-any.whl (96 kB)
Collecting mypy-extensions>=0.4.3
  Using cached mypy_extensions-1.0.0-py3-none-any.whl (4.7 kB)
Collecting packaging>=22.0
  Using cached packaging-23.1-py3-none-any.whl (48 kB)
Collecting pathspec>=0.9.0
  Using cached pathspec-0.11.1-py3-none-any.whl (29 kB)
Collecting tree-sitter
  Using cached tree_sitter-0.20.1-cp311-cp311-macosx_13_0_arm64.whl
Collecting parso<0.8.0,>=0.7.0
  Using cached parso-0.7.1-py2.py3-none-any.whl (109 kB)
Collecting pytoolconfig[global]>=1.2.2
  Using cached pytoolconfig-1.2.5-py3-none-any.whl (16 kB)
Installing collected packages: toposort, ujson, typing_extensions, tree-sitter-builds, tree-sitter, tomli, sv-ttk, send2trash, PyYAML, Pygments, pyflakes, psutil, pluggy, platformdirs, pathspec, parso, packaging, mypy-extensions, isort, dacite, colorama, click, tree_sitter_languages, pytoolconfig, python-jsonrpc-server, pydantic, jedi, black, sansio-lsp-client, python-language-server, rope
Successfully installed PyYAML-6.0 Pygments-2.12.0 black-23.3.0 click-8.1.3 colorama-0.4.6 dacite-1.8.1 isort-5.12.0 jedi-0.17.2 mypy-extensions-1.0.0 packaging-23.1 parso-0.7.1 pathspec-0.11.1 platformdirs-3.8.0 pluggy-1.2.0 psutil-5.9.5 pydantic-1.10.10 pyflakes-2.2.0 python-jsonrpc-server-0.4.0 python-language-server-0.36.2 pytoolconfig-1.2.5 rope-1.9.0 sansio-lsp-client-0.10.0 send2trash-1.8.2 sv-ttk-2.5.2 tomli-2.0.1 toposort-1.10 tree-sitter-0.20.1 tree-sitter-builds-2022.8.27 tree_sitter_languages-1.6.1 typing_extensions-4.7.1 ujson-5.8.0

[notice] A new release of pip is available: 23.0.1 -> 23.1.2
[notice] To update, run: pip install --upgrade pip
❯ python3 -m porcupine
log file: /Users/phil/Library/Logs/Porcupine/2023-07-03T22-20-06.txt
porcupine.plugins.drop_to_open ERROR: dragging files to Porcupine won't work because tkdnd isn't installed
```

After the second commit, Porcupine launches properly after installing `requirements.txt`.

Commit 3 is optional in case version 2023.3.12 of `tree-sitter-builds` is preferable and `tree_sitter_languages` is redundant with that version.