### PR TITLE
Feat: Toolbar

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -19,7 +19,7 @@ jobs:
         path: ./pr
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
         cache: pip
     - run: pip install wheel
     - run: pip install -r requirements-dev.txt

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
         cache: pip
     - run: pip install wheel
     - run: pip install -r requirements.txt -r requirements-dev.txt
@@ -26,13 +26,14 @@ jobs:
         time mypy --platform darwin --python-version 3.8 porcupine docs/extensions.py
         time mypy --platform darwin --python-version 3.9 porcupine docs/extensions.py
         time mypy --platform darwin --python-version 3.10 porcupine docs/extensions.py
+        time mypy --platform darwin --python-version 3.11 porcupine docs/extensions.py
 
   pytest:
     timeout-minutes: 10
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -60,7 +61,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     env:
       # TODO: how to install tkdnd on mac? add instructions to README or make mac app that bundles it
       TCLLIBPATH: ./lib
@@ -82,7 +83,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
         cache: pip
     # TODO: adding these to requirements-dev.txt breaks pip install
     - run: pip install flake8==5.0.4 flake8-tkinter==0.5.0

--- a/.github/workflows/release-builds.yml
+++ b/.github/workflows/release-builds.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
         cache: pip
     - run: pip install wheel
     - run: pip install -r requirements.txt -r requirements-dev.txt

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ celerybeat-schedule
 .env
 
 # virtualenv
+.venv/
 venv/
 ENV/
 env*/

--- a/porcupine/default_filetypes.toml
+++ b/porcupine/default_filetypes.toml
@@ -377,7 +377,6 @@ filename_patterns = ["*.md", "*.markdown"]
 pygments_lexer = "pygments.lexers.MarkdownLexer"
 syntax_highlighter = "tree_sitter"
 tree_sitter_language_name = "markdown"
-autoindent_regexes = {dedent = '.*\.', indent = '^([0-9]+\.|-) .*'}
 
 [YAML]
 filename_patterns = ["*.yml", "*.yaml"]

--- a/porcupine/plugins/autoindent.py
+++ b/porcupine/plugins/autoindent.py
@@ -90,6 +90,8 @@ def after_enter(tab: tabs.FileTab, alt_pressed: bool) -> None:
         if dedent_prev_line:
             tab.textwidget.dedent("insert - 1 line")
 
+    tab.textwidget.event_generate("<<post-autoindent>>")
+
 
 def on_enter_press(
     tab: tabs.FileTab, alt_pressed: bool, event: tkinter.Event[tkinter.Text]

--- a/porcupine/plugins/markdown.py
+++ b/porcupine/plugins/markdown.py
@@ -30,9 +30,7 @@ def _is_list_item(line: str) -> bool:
 
 
 def on_tab_key(
-    tab: tabs.FileTab,
-    event: tkinter.Event[textutils.MainText],
-    shift_pressed: bool,
+    tab: tabs.FileTab, event: tkinter.Event[textutils.MainText], shift_pressed: bool
 ) -> str | None:
     """Indenting and dedenting list items"""
     if tab.settings.get("filetype_name", str) == "Markdown":

--- a/porcupine/plugins/markdown.py
+++ b/porcupine/plugins/markdown.py
@@ -40,11 +40,16 @@ def on_tab_key(
         line = event.widget.get("insert linestart", "insert lineend")
         list_item_status = _is_list_item(line)
 
+        # shift-tab
         if shift_pressed and list_item_status:
             event.widget.dedent("insert linestart")
             return "break"
 
-        if list_item_status:
+        # if it isn't, we want tab to trigger autocomplete instead
+        char_before_cursor_is_space = tab.textwidget.get("insert - 1 char", "insert") == " "
+
+        # tab
+        if list_item_status and char_before_cursor_is_space:
             event.widget.indent("insert linestart")
             return "break"
 

--- a/porcupine/plugins/markdown.py
+++ b/porcupine/plugins/markdown.py
@@ -30,8 +30,10 @@ def _is_list_item(line: str) -> bool:
 
 
 def on_tab_key(
-    tab: tabs.FileTab, event: tkinter.Event[textutils.MainText], shift_pressed: bool
-) -> str:
+    tab: tabs.FileTab,
+    event: tkinter.Event[textutils.MainText],
+    shift_pressed: bool,
+) -> str | None:
     """Indenting and dedenting list items"""
     if tab.settings.get("filetype_name", str) == "Markdown":
         line = event.widget.get("insert linestart", "insert lineend")
@@ -44,6 +46,8 @@ def on_tab_key(
         if list_item_status:
             event.widget.indent("insert linestart")
             return "break"
+
+    return None
 
 
 def on_new_filetab(tab: tabs.FileTab) -> None:

--- a/porcupine/plugins/markdown.py
+++ b/porcupine/plugins/markdown.py
@@ -30,9 +30,7 @@ def _is_list_item(line: str) -> bool:
 
 
 def on_tab_key(
-    tab: tabs.FileTab,
-    event: tkinter.Event[textutils.MainText],
-    shift_pressed: bool,
+    tab: tabs.FileTab, event: tkinter.Event[textutils.MainText], shift_pressed: bool
 ) -> str:
     """Indenting and dedenting list items"""
     if tab.settings.get("filetype_name", str) == "Markdown":

--- a/porcupine/plugins/markdown.py
+++ b/porcupine/plugins/markdown.py
@@ -25,7 +25,13 @@ def _is_list_item(line: str) -> bool:
     - https://spec.commonmark.org/0.30/#lists
     - https://pandoc.org/MANUAL.html#lists
     """
+    assert isinstance(line, str)
+    if not line:
+        # empty string
+        return False
+
     assert len(line.splitlines()) == 1
+
     pattern = r"(^\s*\d{1,9}[.)]|^\s*[-+*]|^\s*#\)|^\s*#\.) .*"
     regex = re.compile(pattern)
     match = regex.search(line)

--- a/porcupine/plugins/markdown.py
+++ b/porcupine/plugins/markdown.py
@@ -1,0 +1,56 @@
+"""If configuration says so, insert spaces when the tab key is pressed."""
+
+from __future__ import annotations
+
+import logging
+import re
+import tkinter
+from functools import partial
+
+from porcupine import get_tab_manager, tabs, textutils, utils
+
+log = logging.getLogger(__name__)
+
+
+setup_before = ["tabs2spaces"]
+
+
+def _is_list_item(line: str) -> bool:
+    """Detect if the line that is passed is a markdown list item
+
+    According to:
+    - https://spec.commonmark.org/0.30/#lists
+    - https://pandoc.org/MANUAL.html#lists
+    """
+    assert len(line.splitlines()) == 1
+    pattern = r"^\s*\d{1,9}[.)]|^\s*[-+*]|^\s*#\)|^\s*#\."
+    regex = re.compile(pattern)
+    match = regex.search(line)
+    return bool(match)
+
+
+def on_tab_key(
+    tab: tabs.FileTab,
+    event: tkinter.Event[textutils.MainText],
+    shift_pressed: bool,
+) -> str:
+    """Indenting and dedenting list items"""
+    if tab.settings.get("filetype_name", str) == "Markdown":
+        line = event.widget.get("insert linestart", "insert lineend")
+        list_item_status = _is_list_item(line)
+
+        if shift_pressed and list_item_status:
+            event.widget.dedent("insert linestart")
+            return "break"
+
+        if list_item_status:
+            event.widget.indent("insert linestart")
+            return "break"
+
+
+def on_new_filetab(tab: tabs.FileTab) -> None:
+    utils.bind_tab_key(tab.textwidget, partial(on_tab_key, tab), add=True)
+
+
+def setup() -> None:
+    get_tab_manager().add_filetab_callback(on_new_filetab)

--- a/porcupine/plugins/markdown.py
+++ b/porcupine/plugins/markdown.py
@@ -23,7 +23,7 @@ def _is_list_item(line: str) -> bool:
     - https://pandoc.org/MANUAL.html#lists
     """
     assert len(line.splitlines()) == 1
-    pattern = r"^\s*\d{1,9}[.)]|^\s*[-+*]|^\s*#\)|^\s*#\."
+    pattern = r"(^\s*\d{1,9}[.)]|^\s*[-+*]|^\s*#\)|^\s*#\.) .*"
     regex = re.compile(pattern)
     match = regex.search(line)
     return bool(match)

--- a/porcupine/plugins/markdown.py
+++ b/porcupine/plugins/markdown.py
@@ -1,4 +1,7 @@
-"""If configuration says so, insert spaces when the tab key is pressed."""
+"""Features for working with Markdown Files.
+
+- Indenting and dedenting lists
+"""
 
 from __future__ import annotations
 

--- a/porcupine/plugins/markdown.py
+++ b/porcupine/plugins/markdown.py
@@ -29,7 +29,6 @@ def _list_item(line: str) -> re.Match[str] | None:
     - https://pandoc.org/MANUAL.html#lists
     Technically `#)` is not in either spec, but I won't tell if you won't
     """
-    print(f"{line=}")
     assert isinstance(line, str)
     if not line:
         # empty string

--- a/porcupine/plugins/markdown.py
+++ b/porcupine/plugins/markdown.py
@@ -45,7 +45,7 @@ def on_tab_key(
     tab: tabs.FileTab, event: tkinter.Event[textutils.MainText], shift_pressed: bool
 ) -> str | None:
     """Indenting and dedenting list items"""
-    if tab.settings.get("filetype_name", str) == "Markdown":
+    if tab.settings.get("filetype_name", object) == "Markdown":
         line = event.widget.get("insert linestart", "insert lineend")
         list_item_status = _list_item(line)
 
@@ -70,7 +70,7 @@ def continue_list(tab: tabs.FileTab, event: tkinter.Event[tkinter.Text]) -> str 
 
     This happens after the `autoindent` plugin automatically handles indentation
     """
-    if tab.settings.get("filetype_name", str) == "Markdown":
+    if tab.settings.get("filetype_name", object) == "Markdown":
         current_line = event.widget.get("insert - 1l linestart", "insert -1l lineend")
         list_item_match = _list_item(current_line)
         if list_item_match:

--- a/porcupine/plugins/python_tools.py
+++ b/porcupine/plugins/python_tools.py
@@ -3,7 +3,6 @@ Format the current file with black or isort.
 
 Available in Tools/Python/Black and Tools/Python/Isort.
 """
-
 from __future__ import annotations
 
 import logging
@@ -14,7 +13,7 @@ from pathlib import Path
 from tkinter import messagebox
 
 from porcupine import menubar, tabs, textutils, utils
-from porcupine.plugins import python_venv
+from porcupine.plugins import python_venv, toolbar
 
 log = logging.getLogger(__name__)
 
@@ -66,3 +65,12 @@ def format_code_in_textwidget(tool: str, tab: tabs.FileTab) -> None:
 def setup() -> None:
     menubar.add_filetab_command("Tools/Python/Black", partial(format_code_in_textwidget, "black"))
     menubar.add_filetab_command("Tools/Python/Isort", partial(format_code_in_textwidget, "isort"))
+
+    buttons = []
+    buttons.append(
+        toolbar.Button(text="Black", command=partial(format_code_in_textwidget, "black"))
+    )
+    buttons.append(
+        toolbar.Button(text="isort", command=partial(format_code_in_textwidget, "isort"))
+    )
+    toolbar.add_button_group(filetype_name="Python", name="Python Tools", buttons=buttons)

--- a/porcupine/plugins/toolbar.py
+++ b/porcupine/plugins/toolbar.py
@@ -1,0 +1,110 @@
+"""Display a toolbar in each file tab."""
+from __future__ import annotations
+
+import dataclasses
+import logging
+import tkinter
+from functools import partial
+from tkinter import ttk
+from typing import Any, Callable, Iterable
+
+from porcupine import get_tab_manager, tabs
+
+log = logging.getLogger(__name__)
+
+setup_after = ["filetypes"]
+
+
+# TODO: add icon (make text optional?)
+@dataclasses.dataclass(kw_only=True)
+class Button:
+    text: str
+    description: str | None = None
+    command: Callable
+
+
+@dataclasses.dataclass(kw_only=True)
+class ButtonGroup:
+    name: str
+    priority: int  # 0 is highest
+    buttons: list[Button]
+    separator: bool = True
+
+
+class SortedButtonGroupList(list[ButtonGroup]):
+    """A of button groups that sorts itself automatically"""
+
+    # no this wasn't necessary, but I am in too deep to stop now
+    # but seriously why isn't there a sorted list type in the stdlib?
+    @classmethod
+    def _key_func(cls, group: ButtonGroup) -> int:
+        return group.priority
+
+    def __init__(self, *args: Iterable[ButtonGroup], **kwargs: ButtonGroup) -> None:
+        super().__init__(*args, **kwargs)
+        self.sort(key=self._key_func)
+
+    def append(self, __item: ButtonGroup) -> None:
+        super().append(__item)
+        self.sort(key=self._key_func)
+
+    def extend(self, __iterable: Iterable[ButtonGroup]) -> None:
+        super().extend(__iterable)
+        self.sort(key=self._key_func)
+
+
+filetype_button_groups_mapping: dict[str, SortedButtonGroupList] = {}
+
+
+def add_button_group(
+    *, filetype_name: str, name: str, buttons: list[Button], priority: int = 0, separator=True
+) -> None:
+    button_group = ButtonGroup(name=name, priority=priority, buttons=buttons, separator=separator)
+    if filetype_button_groups_mapping.get(filetype_name):
+        filetype_button_groups_mapping[filetype_name].append(button_group)
+    else:
+        filetype_button_groups_mapping[filetype_name] = SortedButtonGroupList([button_group])
+
+
+class ToolBar(ttk.Frame):
+    def __init__(self, tab: tabs.FileTab):
+        super().__init__(tab.top_frame, name="toolbar", border=1, relief="raised")
+        self._tab = tab
+
+    def update_buttons(self, tab: tabs.FileTab, junk: object = None) -> None:
+        """Different filetypes have different buttons associated with them."""
+        filetype_name = tab.settings.get("filetype_name", object)
+        button_groups = filetype_button_groups_mapping.get(filetype_name)
+        if not button_groups:
+            return
+
+        for button_group in button_groups:
+            for button in button_group.buttons:
+                ttk.Button(
+                    self,
+                    command=partial(button.command, tab),
+                    style="Statusbar.TButton",
+                    text=button.text,
+                ).pack(side="left", padx=10, pady=5)
+
+
+def on_new_filetab(tab: tabs.FileTab) -> None:
+    toolbar = ToolBar(tab)
+    toolbar.pack(side="bottom", fill="x")
+
+    tab.bind("<<TabSettingChanged:filetype_name>>", partial(toolbar.update_buttons, tab), add=True)
+    toolbar.update_buttons(tab)
+
+
+def update_button_style(junk_event: object = None) -> None:
+    # https://tkdocs.com/tutorial/styles.html
+    # tkinter's style stuff sucks
+    get_tab_manager().tk.eval(
+        "ttk::style configure Statusbar.TButton -padding {10 0} -anchor center"
+    )
+
+
+def setup() -> None:
+    get_tab_manager().add_filetab_callback(on_new_filetab)
+    get_tab_manager().bind("<<ThemeChanged>>", update_button_style, add=True)
+    update_button_style()

--- a/tests/test_fullscreen_plugin.py
+++ b/tests/test_fullscreen_plugin.py
@@ -5,8 +5,13 @@ import pytest
 from porcupine import get_main_window
 from porcupine.menubar import get_menu
 
+try:
+    xvfb_status = "xvfb" in os.environ["XAUTHORITY"]
+except KeyError:
+    xvfb = False
 
-@pytest.mark.skipif(os.getenv("GITHUB_ACTIONS") == "true", reason="fails CI on all platforms")
+
+@pytest.mark.skipif(xvfb_status, reason="fails CI on all platforms")
 def test_basic(wait_until):
     assert not get_main_window().attributes("-fullscreen")
 
@@ -18,7 +23,7 @@ def test_basic(wait_until):
 
 
 # Window managers can toggle full-screen-ness without going through our menubar
-@pytest.mark.skipif(os.getenv("GITHUB_ACTIONS") == "true", reason="fails CI on all platforms")
+@pytest.mark.skipif(xvfb_status, reason="fails CI on all platforms")
 def test_toggled_without_menu_bar(wait_until):
     get_main_window().attributes("-fullscreen", 1)
     wait_until(lambda: bool(get_main_window().attributes("-fullscreen")))

--- a/tests/test_fullscreen_plugin.py
+++ b/tests/test_fullscreen_plugin.py
@@ -5,13 +5,20 @@ import pytest
 from porcupine import get_main_window
 from porcupine.menubar import get_menu
 
-try:
-    xvfb_status = "xvfb" in os.environ["XAUTHORITY"]
-except KeyError:
-    xvfb = False
+github_actions = os.getenv("GITHUB_ACTIONS")
+xauthority = os.getenv("XAUTHORITY")
+
+headless = False
+
+if github_actions is not None:
+    headless = github_actions == "true"
+elif xauthority is not None:
+    headless = "xvfb" in xauthority
 
 
-@pytest.mark.skipif(xvfb_status, reason="fails CI on all platforms")
+pytestmark = pytest.mark.skipif(headless, reason="Does not work in headless environments")
+
+
 def test_basic(wait_until):
     assert not get_main_window().attributes("-fullscreen")
 
@@ -23,7 +30,6 @@ def test_basic(wait_until):
 
 
 # Window managers can toggle full-screen-ness without going through our menubar
-@pytest.mark.skipif(xvfb_status, reason="fails CI on all platforms")
 def test_toggled_without_menu_bar(wait_until):
     get_main_window().attributes("-fullscreen", 1)
     wait_until(lambda: bool(get_main_window().attributes("-fullscreen")))

--- a/tests/test_indent_dedent.py
+++ b/tests/test_indent_dedent.py
@@ -198,28 +198,6 @@ def check_autoindents(filetab, tmp_path):
     return check
 
 
-def test_markdown_autoindent(check_autoindents):
-    check_autoindents(
-        "hello.md",
-        """
-1. Lol and
-wat.
-- Foo and
-bar and
-baz.
-End of list
-""",
-        """
-1. Lol and
-    wat.
-- Foo and
-    bar and
-    baz.
-End of list
-""",
-    )
-
-
 def test_shell_autoindent(check_autoindents):
     check_autoindents(
         "loll.sh",

--- a/tests/test_jump_to_definition_plugin.py
+++ b/tests/test_jump_to_definition_plugin.py
@@ -1,10 +1,18 @@
 # TODO: create much more tests for langserver
+import platform
 import time
 
+import pytest
 from sansio_lsp_client import ClientState
 
 from porcupine import get_main_window
 from porcupine.plugins.langserver import langservers
+
+pytestmark = pytest.mark.xfail(
+    platform.python_version_tuple()[:2] == ("3", "11"),
+    run=False,
+    reason="https://github.com/Akuli/porcupine/issues/1300",
+)
 
 
 def langserver_started(filetab):

--- a/tests/test_markdown_plugin.py
+++ b/tests/test_markdown_plugin.py
@@ -221,7 +221,7 @@ def test_list_continuation(li: str, filetab, tmp_path):
     assert filetab.settings.get("filetype_name", object) == "Markdown"
 
     # new line
-    filetab.update()
     filetab.textwidget.event_generate("<Return>")
-    current_line = filetab.textwidget.get("insert - 1l linestart", "insert - 1l lineend")
+    filetab.update()
+    current_line = filetab.textwidget.get("insert linestart", "insert lineend")
     assert markdown._list_item(current_line)

--- a/tests/test_markdown_plugin.py
+++ b/tests/test_markdown_plugin.py
@@ -24,26 +24,52 @@ IS_LIST_ITEM_CASES = [
     IsListItemCase(id="# bad separator \\", line="#\\ item 1", expected=False),
     IsListItemCase(id="ol bad separator |", line="8| item 1", expected=False),
     IsListItemCase(id="ol bad separator /", line="8/ item 1", expected=False),
-    IsListItemCase(id="ol bad separator \\", line="8\\ item 1", expected=False),
+    IsListItemCase(
+        id="ol bad separator \\", line="8\\ item 1", expected=False
+    ),
     IsListItemCase(id="not a list 1", line="item 1", expected=False),
     IsListItemCase(id="not a list 2", line="   item 1", expected=False),
     IsListItemCase(id="not a list 3", line="          item 1", expected=False),
     IsListItemCase(id="not a list 4", line="& item 1", expected=False),
     IsListItemCase(id="not a list 5", line="^ item 1", expected=False),
-    IsListItemCase(id="duplicate token 1", line="-- item 1", expected=True),
-    IsListItemCase(id="duplicate token 2", line="--- item 1", expected=True),
+    IsListItemCase(id="duplicate token 1", line="-- item 1", expected=False),
+    IsListItemCase(id="duplicate token 2", line="--- item 1", expected=False),
     IsListItemCase(id="duplicate token 3", line="- - - item 1", expected=True),
-    IsListItemCase(id="duplicate token 4", line="  - item -- 1 -", expected=True),
-    IsListItemCase(id="duplicate token 5", line="  -#) item -- 1 -", expected=True),
-    IsListItemCase(id="duplicate token 6", line="  *-#)1. item -- 1 -", expected=True),
+    IsListItemCase(
+        id="duplicate token 4", line="  - item -- 1 -", expected=True
+    ),
+    IsListItemCase(
+        id="duplicate token 5", line="  -#) item -- 1 -", expected=False
+    ),
+    IsListItemCase(
+        id="duplicate token 6", line="  *-#)1. item -- 1 -", expected=False
+    ),
 ]
 
 # test `#` and 0 to 99 numbered lists
 # tests ol with `.` and `)`
 IS_LIST_ITEM_CASES.extend(
     [
-        IsListItemCase(id=f"numbered {i}", line=f"{i}{sep} item 1", expected=True)
-        for i, sep in itertools.product(itertools.chain(range(100), "#"), (".", ")"))
+        IsListItemCase(
+            id=f"numbered {i}", line=f"{i}{sep} item 1", expected=True
+        )
+        for i, sep in itertools.product(
+            itertools.chain(range(100), "#"), (".", ")")
+        )
+    ]
+)
+
+# test raw li prefixes with and without space
+IS_LIST_ITEM_CASES.extend(
+    [
+        IsListItemCase(
+            id=f"raw prexix {prefix} no space",
+            line=f"{prefix}{' ' if space else ''}",
+            expected=space,
+        )
+        for prefix, space in itertools.product(
+            ["1.", "1)", "#.", "#)", "-", "*", "+"], [True, False]
+        )
     ]
 )
 
@@ -69,7 +95,9 @@ IS_LIST_ITEM_CASES.extend(
             line=f"{' ' * preceding}{bullet} {' ' * following} item 1",
             expected=True,
         )
-        for bullet, preceding, following in itertools.product(("-", "*", "+"), range(11), range(11))
+        for bullet, preceding, following in itertools.product(
+            ("-", "*", "+"), range(11), range(11)
+        )
     ]
 )
 
@@ -101,8 +129,8 @@ def test_is_list(line: str, expected: bool, raises):
         "- item 1",
         "* item 1",
         "+ item 1",
-        "++++++ weird",
-        "1)))))) still weird",
+        "+ +++++ weird",
+        "1) ))))) still weird",
         "- [ ] unchecked task",
         "- [X] checked task",
     ],
@@ -124,10 +152,14 @@ def test_filetype_switching(li: str, filetab, tmp_path):
 
     filetab.textwidget.event_generate("<Tab>")
     filetab.update()
-    assert filetab.textwidget.get("1.0", "end - 1 char") == f"    {li}\n", "should indent"
+    assert (
+        filetab.textwidget.get("1.0", "end - 1 char") == f"    {li}\n"
+    ), "should indent"
     filetab.textwidget.event_generate("<Shift-Tab>")
     filetab.update()
-    assert filetab.textwidget.get("1.0", "end - 1 char") == f"{li}\n", "should dedent"
+    assert (
+        filetab.textwidget.get("1.0", "end - 1 char") == f"{li}\n"
+    ), "should dedent"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_markdown_plugin.py
+++ b/tests/test_markdown_plugin.py
@@ -109,6 +109,8 @@ def test_is_list(line: str, expected: bool, raises):
 @pytest.mark.parametrize(
     "li",
     [
+        "-",
+        "1.",
         "1. item 1",
         "1) item 1",
         "#) item 1",
@@ -127,8 +129,9 @@ def test_filetype_switching(li: str, filetab, tmp_path):
     filetab.textwidget.insert("1.0", li)
     filetab.textwidget.event_generate("<Tab>")
     filetab.update()
+
     assert (
-        filetab.textwidget.get("1.0", "end - 1 char") == li
+        filetab.textwidget.get("1.0", "insert") == li
     ), "should not effect list items unless using markdown filetype"
     filetab.textwidget.event_generate("<Escape>")  # close the autocomplete
 
@@ -138,10 +141,17 @@ def test_filetype_switching(li: str, filetab, tmp_path):
 
     filetab.textwidget.event_generate("<Tab>")
     filetab.update()
-    assert filetab.textwidget.get("1.0", "end - 1 char") == f"    {li}\n", "should indent"
+    # no change to text, should open autocomplete menu
+    assert filetab.textwidget.get("1.0", "insert") == li
+    filetab.textwidget.event_generate("<Escape>")  # close the autocomplete
+
+    # add a space
+    filetab.textwidget.insert("insert", " ")
+    filetab.textwidget.event_generate("<Tab>")
+    assert filetab.textwidget.get("1.0", "insert") == f"    {li} ", "should be indented"
     filetab.textwidget.event_generate("<Shift-Tab>")
     filetab.update()
-    assert filetab.textwidget.get("1.0", "end - 1 char") == f"{li}\n", "should dedent"
+    assert filetab.textwidget.get("1.0", "insert") == f"{li} ", "should be back to normal"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_markdown_plugin.py
+++ b/tests/test_markdown_plugin.py
@@ -24,9 +24,7 @@ IS_LIST_ITEM_CASES = [
     IsListItemCase(id="# bad separator \\", line="#\\ item 1", expected=False),
     IsListItemCase(id="ol bad separator |", line="8| item 1", expected=False),
     IsListItemCase(id="ol bad separator /", line="8/ item 1", expected=False),
-    IsListItemCase(
-        id="ol bad separator \\", line="8\\ item 1", expected=False
-    ),
+    IsListItemCase(id="ol bad separator \\", line="8\\ item 1", expected=False),
     IsListItemCase(id="not a list 1", line="item 1", expected=False),
     IsListItemCase(id="not a list 2", line="   item 1", expected=False),
     IsListItemCase(id="not a list 3", line="          item 1", expected=False),
@@ -35,27 +33,17 @@ IS_LIST_ITEM_CASES = [
     IsListItemCase(id="duplicate token 1", line="-- item 1", expected=True),
     IsListItemCase(id="duplicate token 2", line="--- item 1", expected=True),
     IsListItemCase(id="duplicate token 3", line="- - - item 1", expected=True),
-    IsListItemCase(
-        id="duplicate token 4", line="  - item -- 1 -", expected=True
-    ),
-    IsListItemCase(
-        id="duplicate token 5", line="  -#) item -- 1 -", expected=True
-    ),
-    IsListItemCase(
-        id="duplicate token 6", line="  *-#)1. item -- 1 -", expected=True
-    ),
+    IsListItemCase(id="duplicate token 4", line="  - item -- 1 -", expected=True),
+    IsListItemCase(id="duplicate token 5", line="  -#) item -- 1 -", expected=True),
+    IsListItemCase(id="duplicate token 6", line="  *-#)1. item -- 1 -", expected=True),
 ]
 
 # test `#` and 0 to 99 numbered lists
 # tests ol with `.` and `)`
 IS_LIST_ITEM_CASES.extend(
     [
-        IsListItemCase(
-            id=f"numbered {i}", line=f"{i}{sep} item 1", expected=True
-        )
-        for i, sep in itertools.product(
-            itertools.chain(range(100), "#"), (".", ")")
-        )
+        IsListItemCase(id=f"numbered {i}", line=f"{i}{sep} item 1", expected=True)
+        for i, sep in itertools.product(itertools.chain(range(100), "#"), (".", ")"))
     ]
 )
 
@@ -81,9 +69,7 @@ IS_LIST_ITEM_CASES.extend(
             line=f"{' ' * preceding}{bullet} {' ' * following} item 1",
             expected=True,
         )
-        for bullet, preceding, following in itertools.product(
-            ("-", "*", "+"), range(11), range(11)
-        )
+        for bullet, preceding, following in itertools.product(("-", "*", "+"), range(11), range(11))
     ]
 )
 
@@ -138,14 +124,10 @@ def test_filetype_switching(li: str, filetab, tmp_path):
 
     filetab.textwidget.event_generate("<Tab>")
     filetab.update()
-    assert (
-        filetab.textwidget.get("1.0", "end - 1 char") == f"    {li}\n"
-    ), "should indent"
+    assert filetab.textwidget.get("1.0", "end - 1 char") == f"    {li}\n", "should indent"
     filetab.textwidget.event_generate("<Shift-Tab>")
     filetab.update()
-    assert (
-        filetab.textwidget.get("1.0", "end - 1 char") == f"{li}\n"
-    ), "should dedent"
+    assert filetab.textwidget.get("1.0", "end - 1 char") == f"{li}\n", "should dedent"
 
 
 @pytest.mark.parametrize(
@@ -167,8 +149,6 @@ def test_filetype_switching(li: str, filetab, tmp_path):
     ],
 )
 def test_non_list(line: str, filetab, tmp_path):
-    import time
-
     # switch to Markdown filetype format
     filetab.save_as(tmp_path / "asdf.md")
     assert filetab.settings.get("filetype_name", object) == "Markdown"

--- a/tests/test_markdown_plugin.py
+++ b/tests/test_markdown_plugin.py
@@ -148,6 +148,7 @@ def test_filetype_switching(li: str, filetab, tmp_path):
     # add a space
     filetab.textwidget.insert("insert", " ")
     filetab.textwidget.event_generate("<Tab>")
+    filetab.update()
     assert filetab.textwidget.get("1.0", "insert") == f"    {li} ", "should be indented"
     filetab.textwidget.event_generate("<Shift-Tab>")
     filetab.update()

--- a/tests/test_markdown_plugin.py
+++ b/tests/test_markdown_plugin.py
@@ -24,9 +24,7 @@ IS_LIST_ITEM_CASES = [
     IsListItemCase(id="# bad separator \\", line="#\\ item 1", expected=False),
     IsListItemCase(id="ol bad separator |", line="8| item 1", expected=False),
     IsListItemCase(id="ol bad separator /", line="8/ item 1", expected=False),
-    IsListItemCase(
-        id="ol bad separator \\", line="8\\ item 1", expected=False
-    ),
+    IsListItemCase(id="ol bad separator \\", line="8\\ item 1", expected=False),
     IsListItemCase(id="not a list 1", line="item 1", expected=False),
     IsListItemCase(id="not a list 2", line="   item 1", expected=False),
     IsListItemCase(id="not a list 3", line="          item 1", expected=False),
@@ -35,27 +33,17 @@ IS_LIST_ITEM_CASES = [
     IsListItemCase(id="duplicate token 1", line="-- item 1", expected=False),
     IsListItemCase(id="duplicate token 2", line="--- item 1", expected=False),
     IsListItemCase(id="duplicate token 3", line="- - - item 1", expected=True),
-    IsListItemCase(
-        id="duplicate token 4", line="  - item -- 1 -", expected=True
-    ),
-    IsListItemCase(
-        id="duplicate token 5", line="  -#) item -- 1 -", expected=False
-    ),
-    IsListItemCase(
-        id="duplicate token 6", line="  *-#)1. item -- 1 -", expected=False
-    ),
+    IsListItemCase(id="duplicate token 4", line="  - item -- 1 -", expected=True),
+    IsListItemCase(id="duplicate token 5", line="  -#) item -- 1 -", expected=False),
+    IsListItemCase(id="duplicate token 6", line="  *-#)1. item -- 1 -", expected=False),
 ]
 
 # test `#` and 0 to 99 numbered lists
 # tests ol with `.` and `)`
 IS_LIST_ITEM_CASES.extend(
     [
-        IsListItemCase(
-            id=f"numbered {i}", line=f"{i}{sep} item 1", expected=True
-        )
-        for i, sep in itertools.product(
-            itertools.chain(range(100), "#"), (".", ")")
-        )
+        IsListItemCase(id=f"numbered {i}", line=f"{i}{sep} item 1", expected=True)
+        for i, sep in itertools.product(itertools.chain(range(100), "#"), (".", ")"))
     ]
 )
 
@@ -95,9 +83,7 @@ IS_LIST_ITEM_CASES.extend(
             line=f"{' ' * preceding}{bullet} {' ' * following} item 1",
             expected=True,
         )
-        for bullet, preceding, following in itertools.product(
-            ("-", "*", "+"), range(11), range(11)
-        )
+        for bullet, preceding, following in itertools.product(("-", "*", "+"), range(11), range(11))
     ]
 )
 
@@ -152,14 +138,10 @@ def test_filetype_switching(li: str, filetab, tmp_path):
 
     filetab.textwidget.event_generate("<Tab>")
     filetab.update()
-    assert (
-        filetab.textwidget.get("1.0", "end - 1 char") == f"    {li}\n"
-    ), "should indent"
+    assert filetab.textwidget.get("1.0", "end - 1 char") == f"    {li}\n", "should indent"
     filetab.textwidget.event_generate("<Shift-Tab>")
     filetab.update()
-    assert (
-        filetab.textwidget.get("1.0", "end - 1 char") == f"{li}\n"
-    ), "should dedent"
+    assert filetab.textwidget.get("1.0", "end - 1 char") == f"{li}\n", "should dedent"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_markdown_plugin.py
+++ b/tests/test_markdown_plugin.py
@@ -131,29 +131,32 @@ def test_filetype_switching(li: str, filetab, tmp_path):
     assert filetab.settings.get("filetype_name", object) == "Python"
 
     filetab.textwidget.insert("1.0", li)
-    filetab.textwidget.event_generate("<Tab>")
     filetab.update()
+    filetab.textwidget.event_generate("<Tab>")
 
     assert (
         filetab.textwidget.get("1.0", "insert") == li
     ), "should not effect list items unless using markdown filetype"
+    filetab.update()
     filetab.textwidget.event_generate("<Escape>")  # close the autocomplete
 
     # switch to Markdown filetype format
     filetab.save_as(tmp_path / "asdf.md")
     assert filetab.settings.get("filetype_name", object) == "Markdown"
 
-    filetab.textwidget.event_generate("<Tab>")
     filetab.update()
+    filetab.textwidget.event_generate("<Tab>")
     # no change to text, should open autocomplete menu
     assert filetab.textwidget.get("1.0", "insert") == li
+    filetab.update()
     filetab.textwidget.event_generate("<Escape>")  # close the autocomplete
 
     # add a space
     filetab.textwidget.insert("insert", " ")
-    filetab.textwidget.event_generate("<Tab>")
     filetab.update()
+    filetab.textwidget.event_generate("<Tab>")
     assert filetab.textwidget.get("1.0", "insert") == f"    {li} ", "should be indented"
+    filetab.update()
     filetab.textwidget.event_generate("<Shift-Tab>")
     filetab.update()
     assert filetab.textwidget.get("1.0", "insert") == f"{li} ", "should be back to normal"
@@ -183,9 +186,10 @@ def test_non_list(line: str, filetab, tmp_path):
     assert filetab.settings.get("filetype_name", object) == "Markdown"
 
     filetab.textwidget.insert("1.0", line)
-    filetab.textwidget.event_generate("<Tab>")
-    filetab.textwidget.event_generate("<Escape>")  # close the autocomplete
     filetab.update()
+    filetab.textwidget.event_generate("<Tab>")
+    filetab.update()
+    filetab.textwidget.event_generate("<Escape>")  # close the autocomplete
     assert (
         filetab.textwidget.get("1.0", "end - 1 char") == f"{line}\n"
     ), "should not change, just open autocomplete"
@@ -217,7 +221,7 @@ def test_list_continuation(li: str, filetab, tmp_path):
     assert filetab.settings.get("filetype_name", object) == "Markdown"
 
     # new line
-    filetab.textwidget.event_generate("<Return>")
     filetab.update()
+    filetab.textwidget.event_generate("<Return>")
     current_line = filetab.textwidget.get("insert linestart", "insert")
     assert markdown._list_item(current_line)

--- a/tests/test_markdown_plugin.py
+++ b/tests/test_markdown_plugin.py
@@ -171,7 +171,6 @@ def test_non_list(line: str, filetab, tmp_path):
     filetab.textwidget.event_generate("<Tab>")
     filetab.textwidget.event_generate("<Escape>")  # close the autocomplete
     filetab.update()
-    # time.sleep(3)
     assert (
         filetab.textwidget.get("1.0", "end - 1 char") == f"{line}\n"
     ), "should not change, just open autocomplete"

--- a/tests/test_markdown_plugin.py
+++ b/tests/test_markdown_plugin.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import itertools
+from contextlib import nullcontext as does_not_raise
+from typing import NamedTuple
+
+import pytest
+
+from porcupine.plugins import markdown
+
+
+class IsListItemCase(NamedTuple):
+    id: str
+    line: str
+    expected: bool
+    marks: list[pytest.MarkDecorator] = []
+    raises: Exception | None = None
+
+
+IS_LIST_ITEM_CASES = [
+    IsListItemCase(id="# with no separator", line="# item 1", expected=False),
+    IsListItemCase(id="# bad separator |", line="#| item 1", expected=False),
+    IsListItemCase(id="# bad separator /", line="#/ item 1", expected=False),
+    IsListItemCase(id="# bad separator \\", line="#\\ item 1", expected=False),
+    IsListItemCase(id="ol bad separator |", line="8| item 1", expected=False),
+    IsListItemCase(id="ol bad separator /", line="8/ item 1", expected=False),
+    IsListItemCase(
+        id="ol bad separator \\", line="8\\ item 1", expected=False
+    ),
+    IsListItemCase(id="not a list 1", line="item 1", expected=False),
+    IsListItemCase(id="not a list 2", line="   item 1", expected=False),
+    IsListItemCase(id="not a list 3", line="          item 1", expected=False),
+    IsListItemCase(id="not a list 4", line="& item 1", expected=False),
+    IsListItemCase(id="not a list 5", line="^ item 1", expected=False),
+    IsListItemCase(id="duplicate token 1", line="-- item 1", expected=True),
+    IsListItemCase(id="duplicate token 2", line="--- item 1", expected=True),
+    IsListItemCase(id="duplicate token 3", line="- - - item 1", expected=True),
+    IsListItemCase(
+        id="duplicate token 4", line="  - item -- 1 -", expected=True
+    ),
+    IsListItemCase(
+        id="duplicate token 5", line="  -#) item -- 1 -", expected=True
+    ),
+    IsListItemCase(
+        id="duplicate token 6", line="  *-#)1. item -- 1 -", expected=True
+    ),
+]
+
+# test `#` and 0 to 99 numbered lists
+# tests ol with `.` and `)`
+IS_LIST_ITEM_CASES.extend(
+    [
+        IsListItemCase(
+            id=f"numbered {i}", line=f"{i}{sep} item 1", expected=True
+        )
+        for i, sep in itertools.product(
+            itertools.chain(range(100), "#"), (".", ")")
+        )
+    ]
+)
+
+# test numbered list with whitespace following and preceding
+IS_LIST_ITEM_CASES.extend(
+    [
+        IsListItemCase(
+            id=f"numbered {preceding=} {following=} space",
+            line=f"{' ' * preceding}{i}{sep}{' ' * following} item 1",
+            expected=True,
+        )
+        for i, sep, preceding, following in itertools.product(
+            ("7", "#"), (".", ")"), range(11), range(11)
+        )
+    ]
+)
+
+# test with whitespace following and preceding
+IS_LIST_ITEM_CASES.extend(
+    [
+        IsListItemCase(
+            id=f"bullet {preceding=} {following=} space",
+            line=f"{' ' * preceding}{bullet} {' ' * following} item 1",
+            expected=True,
+        )
+        for bullet, preceding, following in itertools.product(
+            ("-", "*", "+"), range(11), range(11)
+        )
+    ]
+)
+
+
+@pytest.mark.parametrize(
+    "line, expected, raises",
+    [
+        pytest.param(
+            case.line,
+            case.expected,
+            pytest.raises(case.raises) if case.raises else does_not_raise(),
+            marks=case.marks,
+            id=case.id,
+        )
+        for case in IS_LIST_ITEM_CASES
+    ],
+)
+def test_is_list(line: str, expected: bool, raises):
+    with raises:
+        assert markdown._is_list_item(line) == expected
+
+
+@pytest.mark.parametrize(
+    "li",
+    [
+        "1. item 1",
+        "1) item 1",
+        "#) item 1",
+        "- item 1",
+        "* item 1",
+        "+ item 1",
+        "++++++ weird",
+        "1)))))) still weird",
+        "- [ ] unchecked task",
+        "- [X] checked task",
+    ],
+)
+def test_filetype_switching(li: str, filetab, tmp_path):
+    assert filetab.settings.get("filetype_name", object) == "Python"
+
+    filetab.textwidget.insert("1.0", li)
+    filetab.textwidget.event_generate("<Tab>")
+    filetab.update()
+    assert (
+        filetab.textwidget.get("1.0", "end - 1 char") == li
+    ), "should not effect list items unless using markdown filetype"
+    filetab.textwidget.event_generate("<Escape>")  # close the autocomplete
+
+    # switch to Markdown filetype format
+    filetab.save_as(tmp_path / "asdf.md")
+    assert filetab.settings.get("filetype_name", object) == "Markdown"
+
+    filetab.textwidget.event_generate("<Tab>")
+    filetab.update()
+    assert (
+        filetab.textwidget.get("1.0", "end - 1 char") == f"    {li}\n"
+    ), "should indent"
+    filetab.textwidget.event_generate("<Shift-Tab>")
+    filetab.update()
+    assert (
+        filetab.textwidget.get("1.0", "end - 1 char") == f"{li}\n"
+    ), "should dedent"
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "# H1 Heading",
+        "## H2 Heading",
+        "   ### H3 Heading with whitespace preceding",
+        "| Markdown    | Table     |",
+        "| :---------------- | :------: | ----: |",
+        "```python",
+        '<h3 id="custom-id">My Great Heading</h3>',
+        ": This is the definition",
+        "~~The world is flat.~~",
+        "==very important words==",
+        "X^2^",
+        "http://www.example.com",
+        "`http://www.example.com`",
+    ],
+)
+def test_non_list(line: str, filetab, tmp_path):
+    import time
+
+    # switch to Markdown filetype format
+    filetab.save_as(tmp_path / "asdf.md")
+    assert filetab.settings.get("filetype_name", object) == "Markdown"
+
+    filetab.textwidget.insert("1.0", line)
+    filetab.textwidget.event_generate("<Tab>")
+    filetab.textwidget.event_generate("<Escape>")  # close the autocomplete
+    filetab.update()
+    # time.sleep(3)
+    assert (
+        filetab.textwidget.get("1.0", "end - 1 char") == f"{line}\n"
+    ), "should not change, just open autocomplete"

--- a/tests/test_markdown_plugin.py
+++ b/tests/test_markdown_plugin.py
@@ -223,5 +223,5 @@ def test_list_continuation(li: str, filetab, tmp_path):
     # new line
     filetab.update()
     filetab.textwidget.event_generate("<Return>")
-    current_line = filetab.textwidget.get("insert linestart", "insert")
+    current_line = filetab.textwidget.get("insert - 1l linestart", "insert - 1l lineend")
     assert markdown._list_item(current_line)

--- a/tests/test_toolbar_plugin.py
+++ b/tests/test_toolbar_plugin.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from porcupine.plugins import toolbar
+
+
+def _gen_button_group(priority: int, name: str | None = None) -> toolbar.ButtonGroup:
+    return toolbar.ButtonGroup(
+        name=f"priority = {priority}" if not name else name, priority=priority, buttons=[]
+    )
+
+
+def test_manual_sorted_button_group_list_with_append_and_extend():
+    # reverse order
+    sorted_button_group_list = toolbar.SortedButtonGroupList(
+        [_gen_button_group(i) for i in [100, 0, 50, 25, 2, 1, 99]]
+    )
+
+    sorted_button_group_list.append(_gen_button_group(33))
+    sorted_button_group_list.append(_gen_button_group(5))
+
+    sorted_button_group_list.extend(
+        [_gen_button_group(9), _gen_button_group(8), _gen_button_group(7)]
+    )
+
+    for i, button_group in zip(
+        [0, 1, 2, 5, 7, 8, 9, 25, 33, 50, 99, 100], sorted_button_group_list
+    ):
+        assert i == button_group.priority
+
+
+def test_big_reversed_sorted_button_group_list():
+    qty = 100
+    # reverse order
+    sorted_button_group_list = toolbar.SortedButtonGroupList(
+        [_gen_button_group(i) for i in reversed(range(qty))]
+    )
+
+    for i, button_group in zip(range(qty), sorted_button_group_list):
+        assert i == button_group.priority


### PR DESCRIPTION
Solves https://github.com/Akuli/porcupine/issues/1332

This is a first pass, looking for feedback.

Please don't get caught up on the current buttons being for `black` and `isort`, I am sure you feel that having a dedicated toolbar for these are not of much value, and I agree, but they were the easiest to start with as an example.

I am seeking feedback on how I implemented the toolbar, and how it is interacted with from other plugins. Ideally we come up wiht a pattern for "registering" "commands" that can be selectively shared between the toolbar, [Command Palette](https://github.com/Akuli/porcupine/issues/1319), [right click menu](https://github.com/Akuli/porcupine/issues/1026), and probably the main menu as well?

Features I have thought of, and their status:
- [ ] better theming/appearance of the toolbar
    - [ ] button colors
    - [ ] button symbols/images
        - [ ] work through the sourcing/svg problem
    - [ ] toolbar separators
    - [ ] toolbar padding
    - [ ] toolbar outline
- [x] way to control ordering of buttons (needs some more thought maybe)
- [x] toolbar only appearing for filetypes that it has buttons registered for
- [ ] user able to disable toolbar on a per-filetype basis
- [x] implement as a plugin such that it (I believe) can be completely disabled

PS I may have gone a bit overboard with the custom classes :sweat_smile: 