### PR TITLE
Feat: Actions

### DIFF
--- a/porcupine/actions.py
+++ b/porcupine/actions.py
@@ -1,0 +1,140 @@
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+from typing import Callable
+
+from porcupine.tabs import FileTab
+
+action_availability_callback = Callable[..., bool]
+
+
+@dataclass(kw_only=True, slots=True, frozen=True)
+class Action:
+    """Action that requires no context in the callback"""
+
+    name: str
+    description: str
+    callback: Callable[..., None]
+    availability_callbacks: list[action_availability_callback] | None = None
+
+
+filetab_action_availability_callback = Callable[[FileTab], bool]
+
+
+@dataclass(kw_only=True, slots=True, frozen=True)
+class FileTabAction:
+    """Action that requires a FileTab to be provided to the callback"""
+
+    name: str
+    description: str
+    callback: Callable[[FileTab], None]
+    availability_callbacks: list[filetab_action_availability_callback] | None = None
+
+
+path_action_availability_callback = Callable[[Path], bool]
+
+
+@dataclass(kw_only=True, slots=True, frozen=True)
+class PathAction:
+    """Action that requires a Path to be provided to the callback"""
+
+    name: str
+    description: str
+    callback: Callable[[Path], None]
+    file_compatible: bool = True
+    directory_compatible: bool = False
+    availability_callbacks: list[path_action_availability_callback] | None = None
+
+
+ActionTypes = Action | FileTabAction | PathAction
+
+_actions: dict[str, ActionTypes] = {}
+
+
+def register_action(
+    *,
+    name: str,
+    description: str,
+    callback: Callable[..., None],
+    availability_callbacks: list[action_availability_callback] | None = None,
+) -> Action:
+    if name in _actions:
+        raise ValueError(f"Action with the name '{name}' already exists")
+    action = Action(
+        name=name,
+        description=description,
+        callback=callback,
+        availability_callbacks=availability_callbacks,
+    )
+    _actions[name] = action
+    return action
+
+
+def register_filetab_action(
+    *,
+    name: str,
+    description: str,
+    callback: Callable[[FileTab], None],
+    availability_callbacks: list[filetab_action_availability_callback] | None,
+) -> FileTabAction:
+    if name in _actions:
+        raise ValueError(f"Action with the name '{name}' already exists")
+    action = FileTabAction(
+        name=name,
+        description=description,
+        callback=callback,
+        availability_callbacks=availability_callbacks,
+    )
+    _actions[name] = action
+    return action
+
+
+def register_path_action(
+    *,
+    name: str,
+    description: str,
+    callback: Callable[[Path], None],
+    file_compatible: bool = True,
+    directory_compatible: bool = False,
+    availability_callbacks: list[path_action_availability_callback] | None,
+) -> PathAction:
+    if name in _actions:
+        raise ValueError(f"Action with the name '{name}' already exists")
+    action = PathAction(
+        name=name,
+        description=description,
+        callback=callback,
+        file_compatible=file_compatible,
+        directory_compatible=directory_compatible,
+        availability_callbacks=availability_callbacks,
+    )
+    _actions[name] = action
+    return action
+
+
+def filetype_availability(filetypes: list[str]) -> Callable[[FileTab | Path], bool]:
+    def _filetype_availability(filetypes: list[str], context: FileTab | Path) -> bool:
+        if isinstance(context, FileTab):
+            tab = context
+            if tab.settings.get("filetype_name", object) in filetypes:
+                return True
+            return False
+
+        if isinstance(context, Path):
+            path = context
+
+            if not path.exists():
+                raise RuntimeError(f"{path} does not exist.")
+            if path.is_dir():
+                raise RuntimeError(
+                    f"{path} is a directory - an action consumer registered this action incorrectly"
+                )
+            if not path.is_file():
+                raise RuntimeError(f"{path} is not a file")
+
+            # return True if get_filetype_from_path(path) in filetypes else False
+            raise NotImplementedError  # TODO: there is a way to do this already right?
+
+        raise RuntimeError("wrong context passed")
+
+    return partial(_filetype_availability, filetypes)

--- a/porcupine/actions.py
+++ b/porcupine/actions.py
@@ -50,7 +50,7 @@ Action = Union[BareAction, FileTabAction, PathAction]
 _actions: dict[str, Action] = {}
 
 
-def register_action(
+def register_bare_action(
     *,
     name: str,
     description: str,

--- a/porcupine/actions.py
+++ b/porcupine/actions.py
@@ -8,7 +8,7 @@ from porcupine.tabs import FileTab
 action_availability_callback = Callable[[], bool]
 
 
-@dataclass(slots=True, frozen=True)
+@dataclass(frozen=True)
 class Action:
     """Action that requires no context in the callback"""
 
@@ -21,7 +21,7 @@ class Action:
 filetab_action_availability_callback = Callable[[FileTab], bool]
 
 
-@dataclass(slots=True, frozen=True)
+@dataclass(frozen=True)
 class FileTabAction:
     """Action that requires a FileTab to be provided to the callback"""
 
@@ -34,7 +34,7 @@ class FileTabAction:
 path_action_availability_callback = Callable[[Path], bool]
 
 
-@dataclass(slots=True, frozen=True)
+@dataclass(frozen=True)
 class PathAction:
     """Action that requires a Path to be provided to the callback"""
 

--- a/porcupine/actions.py
+++ b/porcupine/actions.py
@@ -8,7 +8,7 @@ from porcupine.tabs import FileTab
 action_availability_callback = Callable[[], bool]
 
 
-@dataclass(kw_only=True, slots=True, frozen=True)
+@dataclass(slots=True, frozen=True)
 class Action:
     """Action that requires no context in the callback"""
 
@@ -21,7 +21,7 @@ class Action:
 filetab_action_availability_callback = Callable[[FileTab], bool]
 
 
-@dataclass(kw_only=True, slots=True, frozen=True)
+@dataclass(slots=True, frozen=True)
 class FileTabAction:
     """Action that requires a FileTab to be provided to the callback"""
 
@@ -34,7 +34,7 @@ class FileTabAction:
 path_action_availability_callback = Callable[[Path], bool]
 
 
-@dataclass(kw_only=True, slots=True, frozen=True)
+@dataclass(slots=True, frozen=True)
 class PathAction:
     """Action that requires a Path to be provided to the callback"""
 

--- a/porcupine/actions.py
+++ b/porcupine/actions.py
@@ -108,29 +108,9 @@ def register_path_action(
     return action
 
 
-def filetype_availability(filetypes: list[str]) -> Callable[[FileTab | Path], bool]:
-    def _filetype_availability(filetypes: list[str], context: FileTab | Path) -> bool:
-        if isinstance(context, FileTab):
-            tab = context
-            if tab.settings.get("filetype_name", object) in filetypes:
-                return True
-            return False
+def query_actions(name: str) -> Action | None:
+    return _actions.get(name)
 
-        if isinstance(context, Path):
-            path = context
 
-            if not path.exists():
-                raise RuntimeError(f"{path} does not exist.")
-            if path.is_dir():
-                raise RuntimeError(
-                    f"{path} is a directory - an action consumer registered this action incorrectly"
-                )
-            if not path.is_file():
-                raise RuntimeError(f"{path} is not a file")
-
-            # return True if get_filetype_from_path(path) in filetypes else False
-            raise NotImplementedError  # TODO: there is a way to do this already right?
-
-        raise RuntimeError("wrong context passed")
-
-    return partial(_filetype_availability, filetypes)
+def get_all_actions() -> dict[str, Action]:
+    return _actions.copy()

--- a/porcupine/actions.py
+++ b/porcupine/actions.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Union
 
 from porcupine.tabs import FileTab
 
@@ -46,7 +48,7 @@ class PathAction:
     availability_callbacks: list[path_action_availability_callback] | None = None
 
 
-ActionTypes = Action | FileTabAction | PathAction
+ActionTypes = Union[Action, FileTabAction, PathAction]
 
 _actions: dict[str, ActionTypes] = {}
 

--- a/porcupine/actions.py
+++ b/porcupine/actions.py
@@ -16,7 +16,7 @@ class Action:
 
     name: str
     description: str
-    callback: Callable[..., None]
+    callback: Callable[[], None]
     availability_callbacks: list[action_availability_callback] | None = None
 
 

--- a/porcupine/actions.py
+++ b/porcupine/actions.py
@@ -70,7 +70,7 @@ def register_filetab_action(
     availability_callback: Callable[[FileTab], bool] = lambda tab: True,
 ) -> FileTabAction:
     if name in _actions:
-        raise ValueError(f"Action with the name '{name}' already exists")
+        raise ValueError(f"Action with the name {name!r} already exists")
     action = FileTabAction(
         name=name,
         description=description,
@@ -89,7 +89,7 @@ def register_path_action(
     availability_callback: Callable[[Path], bool] = lambda path: True,
 ) -> PathAction:
     if name in _actions:
-        raise ValueError(f"Action with the name '{name}' already exists")
+        raise ValueError(f"Action with the name {name!r} already exists")
     action = PathAction(
         name=name,
         description=description,

--- a/porcupine/actions.py
+++ b/porcupine/actions.py
@@ -111,7 +111,7 @@ def get_all_actions() -> dict[str, Action]:
 # Availability Helpers
 
 
-def filetype_is(filetypes: Union[list[str], str]) -> Callable[[FileTab], bool]:
+def filetype_is(filetypes: str | list[str]) -> Callable[[FileTab], bool]:
     def _filetype_is(filetypes: list[str], tab: FileTab) -> bool:
         try:
             filetype = tab.settings.get("filetype_name", object)

--- a/porcupine/actions.py
+++ b/porcupine/actions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from functools import partial
 from pathlib import Path
 from typing import Callable, Union
 

--- a/porcupine/actions.py
+++ b/porcupine/actions.py
@@ -100,7 +100,7 @@ def register_path_action(
     return action
 
 
-def query_actions(name: str) -> Action | None:
+def get_action(name: str) -> Action | None:
     return _actions.get(name)
 
 

--- a/porcupine/actions.py
+++ b/porcupine/actions.py
@@ -6,8 +6,6 @@ from typing import Callable, Union
 
 from porcupine.tabs import FileTab
 
-action_availability_callback = Callable[[], bool]
-
 
 @dataclass(frozen=True)
 class BareAction:
@@ -16,10 +14,7 @@ class BareAction:
     name: str
     description: str
     callback: Callable[[], None]
-    availability_callback: action_availability_callback
-
-
-filetab_action_availability_callback = Callable[[FileTab], bool]
+    availability_callback: Callable[[], bool]
 
 
 @dataclass(frozen=True)
@@ -29,10 +24,7 @@ class FileTabAction:
     name: str
     description: str
     callback: Callable[[FileTab], None]
-    availability_callback: filetab_action_availability_callback
-
-
-path_action_availability_callback = Callable[[Path], bool]
+    availability_callback: Callable[[FileTab], bool]
 
 
 @dataclass(frozen=True)
@@ -42,7 +34,7 @@ class PathAction:
     name: str
     description: str
     callback: Callable[[Path], None]
-    availability_callback: path_action_availability_callback
+    availability_callback: Callable[[Path], bool]
 
 
 Action = Union[BareAction, FileTabAction, PathAction]
@@ -55,7 +47,7 @@ def register_bare_action(
     name: str,
     description: str,
     callback: Callable[..., None],
-    availability_callback: action_availability_callback = lambda: True,
+    availability_callback: Callable[[], bool] = lambda: True,
 ) -> BareAction:
     if name in _actions:
         raise ValueError(f"Action with the name '{name}' already exists")
@@ -74,7 +66,7 @@ def register_filetab_action(
     name: str,
     description: str,
     callback: Callable[[FileTab], None],
-    availability_callback: filetab_action_availability_callback = lambda tab: True,
+    availability_callback: Callable[[FileTab], bool] = lambda tab: True,
 ) -> FileTabAction:
     if name in _actions:
         raise ValueError(f"Action with the name '{name}' already exists")
@@ -93,7 +85,7 @@ def register_path_action(
     name: str,
     description: str,
     callback: Callable[[Path], None],
-    availability_callback: path_action_availability_callback = lambda path: True,
+    availability_callback: Callable[[Path], bool] = lambda path: True,
 ) -> PathAction:
     if name in _actions:
         raise ValueError(f"Action with the name '{name}' already exists")

--- a/porcupine/actions.py
+++ b/porcupine/actions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from typing import Callable, Union
 
@@ -105,3 +106,22 @@ def query_actions(name: str) -> Action | None:
 
 def get_all_actions() -> dict[str, Action]:
     return _actions.copy()
+
+
+# Availability Helpers
+
+
+def filetype_is(filetypes: Union[list[str], str]) -> Callable[[FileTab], bool]:
+    def _filetype_is(filetypes: list[str], tab: FileTab) -> bool:
+        try:
+            filetype = tab.settings.get("filetype_name", object)
+        except KeyError:
+            # don't ask me why a `get` method can raise a KeyError :p
+            return False
+
+        return filetype in filetypes
+
+    if isinstance(filetypes, str):
+        filetypes = [filetypes]
+
+    return partial(_filetype_is, filetypes)

--- a/porcupine/actions.py
+++ b/porcupine/actions.py
@@ -5,7 +5,7 @@ from typing import Callable
 
 from porcupine.tabs import FileTab
 
-action_availability_callback = Callable[..., bool]
+action_availability_callback = Callable[[], bool]
 
 
 @dataclass(kw_only=True, slots=True, frozen=True)

--- a/porcupine/actions.py
+++ b/porcupine/actions.py
@@ -51,7 +51,7 @@ def register_bare_action(
     availability_callback: Callable[[], bool] = lambda: True,
 ) -> BareAction:
     if name in _actions:
-        raise ValueError(f"Action with the name '{name}' already exists")
+        raise ValueError(f"Action with the name {name!r} already exists")
     action = BareAction(
         name=name,
         description=description,

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -249,7 +249,7 @@ def update_keyboard_shortcuts() -> None:
 
 
 def set_enabled_based_on_tab(
-    path: str, callback: Callable[[tabs.Tab], bool]
+    path: str, callback: Callable[[tabs.FileTab], bool]
 ) -> Callable[..., None]:
     """Use this for disabling menu items depending on the currently selected tab.
 
@@ -293,6 +293,11 @@ def set_enabled_based_on_tab(
         if not tab:
             menu.entryconfig(index, state="disabled")
             return
+
+        if not isinstance(tab, tabs.FileTab):
+            menu.entryconfig(index, state="disabled")
+            return
+
         menu.entryconfig(index, state=("normal" if callback(tab) else "disabled"))
 
     update_enabledness()

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -249,7 +249,7 @@ def update_keyboard_shortcuts() -> None:
 
 
 def set_enabled_based_on_tab(
-    path: str, callback: Callable[[tabs.FileTab], bool]
+    path: str, callback: Callable[[tabs.FileTab], bool], filetab_only: bool = False
 ) -> Callable[..., None]:
     """Use this for disabling menu items depending on the currently selected tab.
 
@@ -291,10 +291,6 @@ def set_enabled_based_on_tab(
         if index is None:
             raise LookupError(f"menu item {path!r} not found")
         if not tab:
-            menu.entryconfig(index, state="disabled")
-            return
-
-        if not isinstance(tab, tabs.FileTab):
             menu.entryconfig(index, state="disabled")
             return
 
@@ -343,8 +339,7 @@ def add_filetab_action(path: str, action: actions.FileTabAction, **kwargs: Any) 
     """
     This is a convenience function that does several things:
 
-    * Create a menu item at the given path. If the path has a trailing
-      / the menu item is obtained from the action object.
+    * Create a menu item at the given path with action.name as label
     * Ensure the menu item is enabled only when the selected tab is a
       :class:`~porcupine.tabs.FileTab` AND when
       :class:`~porcupine.actions.FileTabAction.availability_callback`
@@ -362,7 +357,11 @@ def add_filetab_action(path: str, action: actions.FileTabAction, **kwargs: Any) 
     get_menu(path).add_command(
         label=action.name, command=lambda: action.callback(get_filetab()), **kwargs
     )
-    set_enabled_based_on_tab(path, action.availability_callback)
+    set_enabled_based_on_tab(
+        path,
+        callback=lambda tab: (lambda tab: isinstance(tab, tabs.FileTab))(tab)
+        and action.availability_callback(tab),
+    )
 
 
 # TODO: pluginify?

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -334,7 +334,8 @@ def add_filetab_action(path: str, action: actions.FileTabAction, **kwargs: Any) 
     """
     This is a convenience function that does several things:
 
-    * Create a menu item at the given path.
+    * Create a menu item at the given path. If the path has a trailing
+      / the menu item is obtained from the action object.
     * Ensure the menu item is enabled only when the selected tab is a
       :class:`~porcupine.tabs.FileTab` AND when
       :class:`~porcupine.actions.FileTabAction.availability_callback`
@@ -348,7 +349,17 @@ def add_filetab_action(path: str, action: actions.FileTabAction, **kwargs: Any) 
     You usually don't need to provide any keyword arguments in ``**kwargs``,
     but if you do, they are passed to :meth:`tkinter.Menu.add_command`.
     """
-    menu_path, item_text = _split_parent(path)
+    if path[-1] == "/":
+        # we get the label from the action.name
+        menu_path = path[:-1]
+        item_text = action.name
+
+        path = f"{menu_path}/{item_text}"
+
+    else:
+        # a full path has been passed, including the label
+        menu_path, item_text = _split_parent(path)
+
     get_menu(menu_path).add_command(
         label=item_text, command=lambda: action.callback(get_filetab()), **kwargs
     )

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -255,9 +255,7 @@ def register_enabledness_check_event(event: str) -> None:
     get_tab_manager().bind(event, _refresh_menu_item_enabledness, add=True)
 
 
-def set_enabled_based_on_tab(
-    path: str, callback: Callable[[tabs.Tab], bool], filetab_only: bool = False
-) -> None:
+def set_enabled_based_on_tab(path: str, callback: Callable[[tabs.Tab], bool]) -> None:
     """Use this for disabling menu items depending on the currently selected tab.
 
     When the selected :class:`~porcupine.tabs.Tab` changes, ``callback`` will

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -359,7 +359,7 @@ def add_filetab_action(path: str, action: actions.FileTabAction, **kwargs: Any) 
     )
     set_enabled_based_on_tab(
         path,
-        callback=lambda tab: (lambda tab: isinstance(tab, tabs.FileTab))(tab)
+        callback=lambda tab: isinstance(tab, tabs.FileTab)
         and action.availability_callback(tab),
     )
 

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -359,8 +359,7 @@ def add_filetab_action(path: str, action: actions.FileTabAction, **kwargs: Any) 
     )
     set_enabled_based_on_tab(
         path,
-        callback=lambda tab: isinstance(tab, tabs.FileTab)
-        and action.availability_callback(tab),
+        callback=lambda tab: isinstance(tab, tabs.FileTab) and action.availability_callback(tab),
     )
 
 

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -249,7 +249,7 @@ def update_keyboard_shortcuts() -> None:
 
 
 def set_enabled_based_on_tab(
-    path: str, callback: Callable[[tabs.FileTab], bool], filetab_only: bool = False
+    path: str, callback: Callable[[tabs.Tab], bool], filetab_only: bool = False
 ) -> Callable[..., None]:
     """Use this for disabling menu items depending on the currently selected tab.
 

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -304,11 +304,10 @@ def set_enabled_based_on_tab(
         index = _find_item(menu, child)
         if index is None:
             raise LookupError(f"menu item {path!r} not found")
-        if not tab:
+        if tab is not None and callback(tab):
+            menu.entryconfig(index, state="normal")
+        else:
             menu.entryconfig(index, state="disabled")
-            return
-
-        menu.entryconfig(index, state=("normal" if callback(tab) else "disabled"))
 
     update_enabledness(path=path)
 

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -249,7 +249,7 @@ def update_keyboard_shortcuts() -> None:
 
 
 def set_enabled_based_on_tab(
-    path: str, callback: Callable[[tabs.Tab | None], bool]
+    path: str, callback: Callable[[tabs.Tab], bool]
 ) -> Callable[..., None]:
     """Use this for disabling menu items depending on the currently selected tab.
 
@@ -284,11 +284,15 @@ def set_enabled_based_on_tab(
 
     def update_enabledness(*junk: object) -> None:
         tab = get_tab_manager().select()
+
         parent, child = _split_parent(path)
         menu = get_menu(parent)
         index = _find_item(menu, child)
         if index is None:
             raise LookupError(f"menu item {path!r} not found")
+        if not tab:
+            menu.entryconfig(index, state="disabled")
+            return
         menu.entryconfig(index, state=("normal" if callback(tab) else "disabled"))
 
     update_enabledness()

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from porcupine import actions
+
 import logging
 import re
 import sys
@@ -10,6 +10,8 @@ from pathlib import Path
 from string import ascii_lowercase
 from tkinter import filedialog
 from typing import Any, Callable, Iterator
+
+from porcupine import actions
 
 if sys.version_info >= (3, 8):
     from typing import Literal

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -297,7 +297,9 @@ def set_enabled_based_on_tab(
         menu.entryconfig(index, state=("normal" if callback(tab) else "disabled"))
 
     update_enabledness()
+    get_tab_manager().bind("<<TabFiletypeApplied>>", update_enabledness, add=True)
     get_tab_manager().bind("<<NotebookTabChanged>>", update_enabledness, add=True)
+
     return update_enabledness
 
 

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+from porcupine import actions
 import logging
 import re
 import sys
@@ -326,6 +326,31 @@ def add_filetab_command(path: str, func: Callable[[tabs.FileTab], object], **kwa
     menu_path, item_text = _split_parent(path)
     get_menu(menu_path).add_command(label=item_text, command=lambda: func(get_filetab()), **kwargs)
     set_enabled_based_on_tab(path, (lambda tab: isinstance(tab, tabs.FileTab)))
+
+
+def add_filetab_action(path: str, action: actions.FileTabAction, **kwargs: Any) -> None:
+    """
+    This is a convenience function that does several things:
+
+    * Create a menu item at the given path.
+    * Ensure the menu item is enabled only when the selected tab is a
+      :class:`~porcupine.tabs.FileTab` AND when
+      :class:`~porcupine.actions.FileTabAction.availability_callback`
+      evaluates to True.
+    * Run :class:`~porcupine.actions.FileTabAction.callback` when the
+      menu item is clicked.
+
+    The ``callback`` is called with the selected tab as the only
+    argument when the menu item is clicked.
+
+    You usually don't need to provide any keyword arguments in ``**kwargs``,
+    but if you do, they are passed to :meth:`tkinter.Menu.add_command`.
+    """
+    menu_path, item_text = _split_parent(path)
+    get_menu(menu_path).add_command(
+        label=item_text, command=lambda: action.callback(get_filetab()), **kwargs
+    )
+    set_enabled_based_on_tab(path, action.availability_callback)
 
 
 # TODO: pluginify?

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -343,7 +343,7 @@ def add_filetab_action(path: str, action: actions.FileTabAction, **kwargs: Any) 
     * Ensure the menu item is enabled only when the selected tab is a
       :class:`~porcupine.tabs.FileTab` AND when
       :class:`~porcupine.actions.FileTabAction.availability_callback`
-      evaluates to True.
+      returns True.
     * Run :class:`~porcupine.actions.FileTabAction.callback` when the
       menu item is clicked.
 

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -353,19 +353,9 @@ def add_filetab_action(path: str, action: actions.FileTabAction, **kwargs: Any) 
     You usually don't need to provide any keyword arguments in ``**kwargs``,
     but if you do, they are passed to :meth:`tkinter.Menu.add_command`.
     """
-    if path[-1] == "/":
-        # we get the label from the action.name
-        menu_path = path[:-1]
-        item_text = action.name
 
-        path = f"{menu_path}/{item_text}"
-
-    else:
-        # a full path has been passed, including the label
-        menu_path, item_text = _split_parent(path)
-
-    get_menu(menu_path).add_command(
-        label=item_text, command=lambda: action.callback(get_filetab()), **kwargs
+    get_menu(path).add_command(
+        label=action.name, command=lambda: action.callback(get_filetab()), **kwargs
     )
     set_enabled_based_on_tab(path, action.availability_callback)
 

--- a/porcupine/plugins/filetypes.py
+++ b/porcupine/plugins/filetypes.py
@@ -252,6 +252,8 @@ def _add_filetype_menuitem(name: str, tk_var: tkinter.StringVar) -> None:
 
 
 def setup() -> None:
+    menubar.register_enabledness_check_event("<<TabFiletypeApplied>>")
+
     global_settings.add_option("default_filetype", "Python")
 
     # load_filetypes() got already called in setup_argument_parser()

--- a/porcupine/plugins/filetypes.py
+++ b/porcupine/plugins/filetypes.py
@@ -224,6 +224,8 @@ def apply_filetype_to_tab(filetype: FileType, tab: tabs.FileTab) -> None:
             if name not in {"filename_patterns", "shebang_regex"}:
                 tab.settings.set(name, value, from_config=True, tag="from_filetype")
 
+    get_tab_manager().event_generate("<<TabFiletypeApplied>>")
+
 
 def on_path_changed(tab: tabs.FileTab, junk: object = None) -> None:
     log.info(f"file path changed: {tab.path}")

--- a/porcupine/plugins/python_tools.py
+++ b/porcupine/plugins/python_tools.py
@@ -67,7 +67,7 @@ black_format_tab = actions.register_filetab_action(
     name="Black Format Tab",
     description="Autoformat open tab using Black",
     callback=partial(format_code_in_textwidget, "black"),
-    availability_callback=lambda tab: isinstance(tab, tabs.FileTab),
+    availability_callback=lambda tab: True,
 )
 
 isort_format_tab = actions.register_filetab_action(

--- a/porcupine/plugins/python_tools.py
+++ b/porcupine/plugins/python_tools.py
@@ -74,7 +74,7 @@ isort_format_tab = actions.register_filetab_action(
     name="isort Format Tab",
     description="Sort Imports of open tab with isort",
     callback=partial(format_code_in_textwidget, "isort"),
-    availability_callback=lambda tab: isinstance(tab, tabs.FileTab),
+    availability_callback=lambda tab: True,
 )
 
 

--- a/porcupine/plugins/python_tools.py
+++ b/porcupine/plugins/python_tools.py
@@ -68,15 +68,15 @@ def setup() -> None:
         name="Black Format Tab",
         description="Autoformat open tab using Black",
         callback=partial(format_code_in_textwidget, "black"),
-        availability_callback=lambda tab: True,
+        availability_callback=actions.filetype_is("Python"),
     )
 
     isort_format_tab_action = actions.register_filetab_action(
         name="isort Format Tab",
         description="Sort Imports of open tab with isort",
         callback=partial(format_code_in_textwidget, "isort"),
-        availability_callback=lambda tab: True,
+        availability_callback=actions.filetype_is("Python"),
     )
 
-    menubar.add_filetab_action("Tools/Python/", black_format_tab_action)
-    menubar.add_filetab_action("Tools/Python/", isort_format_tab_action)
+    menubar.add_filetab_action("Tools/Python", black_format_tab_action)
+    menubar.add_filetab_action("Tools/Python", isort_format_tab_action)

--- a/porcupine/plugins/python_tools.py
+++ b/porcupine/plugins/python_tools.py
@@ -79,5 +79,5 @@ isort_format_tab = actions.register_filetab_action(
 
 
 def setup() -> None:
-    menubar.add_filetab_action("Tools/Python/Black", black_format_tab)
-    menubar.add_filetab_action("Tools/Python/Isort", isort_format_tab)
+    menubar.add_filetab_action("Tools/Python/", black_format_tab)
+    menubar.add_filetab_action("Tools/Python/", isort_format_tab)

--- a/porcupine/plugins/python_tools.py
+++ b/porcupine/plugins/python_tools.py
@@ -13,7 +13,7 @@ from functools import partial
 from pathlib import Path
 from tkinter import messagebox
 
-from porcupine import menubar, tabs, textutils, utils
+from porcupine import menubar, tabs, textutils, utils, actions
 from porcupine.plugins import python_venv
 
 log = logging.getLogger(__name__)
@@ -63,6 +63,21 @@ def format_code_in_textwidget(tool: str, tab: tabs.FileTab) -> None:
             tab.textwidget.replace("1.0", "end - 1 char", after)
 
 
+black_format_tab = actions.register_filetab_action(
+    name="Black Format Tab",
+    description="Autoformat open tab using Black",
+    callback=partial(format_code_in_textwidget, "black"),
+    availability_callback=lambda tab: isinstance(tab, tabs.FileTab),
+)
+
+isort_format_tab = actions.register_filetab_action(
+    name="isort Format Tab",
+    description="Sort Imports of open tab with isort",
+    callback=partial(format_code_in_textwidget, "isort"),
+    availability_callback=lambda tab: isinstance(tab, tabs.FileTab),
+)
+
+
 def setup() -> None:
-    menubar.add_filetab_command("Tools/Python/Black", partial(format_code_in_textwidget, "black"))
-    menubar.add_filetab_command("Tools/Python/Isort", partial(format_code_in_textwidget, "isort"))
+    menubar.add_filetab_action("Tools/Python/Black", black_format_tab)
+    menubar.add_filetab_action("Tools/Python/Isort", isort_format_tab)

--- a/porcupine/plugins/python_tools.py
+++ b/porcupine/plugins/python_tools.py
@@ -63,21 +63,20 @@ def format_code_in_textwidget(tool: str, tab: tabs.FileTab) -> None:
             tab.textwidget.replace("1.0", "end - 1 char", after)
 
 
-black_format_tab = actions.register_filetab_action(
-    name="Black Format Tab",
-    description="Autoformat open tab using Black",
-    callback=partial(format_code_in_textwidget, "black"),
-    availability_callback=lambda tab: True,
-)
-
-isort_format_tab = actions.register_filetab_action(
-    name="isort Format Tab",
-    description="Sort Imports of open tab with isort",
-    callback=partial(format_code_in_textwidget, "isort"),
-    availability_callback=lambda tab: True,
-)
-
-
 def setup() -> None:
-    menubar.add_filetab_action("Tools/Python/", black_format_tab)
-    menubar.add_filetab_action("Tools/Python/", isort_format_tab)
+    black_format_tab_action = actions.register_filetab_action(
+        name="Black Format Tab",
+        description="Autoformat open tab using Black",
+        callback=partial(format_code_in_textwidget, "black"),
+        availability_callback=lambda tab: True,
+    )
+
+    isort_format_tab_action = actions.register_filetab_action(
+        name="isort Format Tab",
+        description="Sort Imports of open tab with isort",
+        callback=partial(format_code_in_textwidget, "isort"),
+        availability_callback=lambda tab: True,
+    )
+
+    menubar.add_filetab_action("Tools/Python/", black_format_tab_action)
+    menubar.add_filetab_action("Tools/Python/", isort_format_tab_action)

--- a/porcupine/plugins/python_tools.py
+++ b/porcupine/plugins/python_tools.py
@@ -13,7 +13,7 @@ from functools import partial
 from pathlib import Path
 from tkinter import messagebox
 
-from porcupine import menubar, tabs, textutils, utils, actions
+from porcupine import actions, menubar, tabs, textutils, utils
 from porcupine.plugins import python_venv
 
 log = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.ruff]
+ignore = ["E501"]
+
 [tool.black]
 line-length = 100
 skip-magic-trailing-comma = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
-[tool.ruff]
-ignore = ["E501"]
-
 [tool.black]
 line-length = 100
 skip-magic-trailing-comma = true
@@ -9,6 +6,9 @@ skip-magic-trailing-comma = true
 line_length = 100
 profile = "black"
 multi_line_output = 3
+
+[tool.ruff]
+ignore = ["E501"]
 
 # Flit configuration ([build-system] and [project]) are used when pip installing with github url.
 # See commands in README.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,6 @@ line_length = 100
 profile = "black"
 multi_line_output = 3
 
-[tool.ruff]
-ignore = ["E501"]
-
 # Flit configuration ([build-system] and [project]) are used when pip installing with github url.
 # See commands in README.
 [build-system]

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -22,3 +22,8 @@ def test_action_registry():
         assert action in all_actions.values()
 
     assert actions.query_actions("nonexistent action") is None
+
+    all_actions["garbage"] = "mean lean fighting machine"  # type: ignore
+    assert (
+        actions.query_actions("garbage") is None
+    ), "`all_actions` should be a copy, changes to it should not effect `_actions`"

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -18,12 +18,12 @@ def test_action_registry():
 
     all_actions = actions.get_all_actions()
     for action in [bare_action, filetab_action, path_action]:
-        assert actions.query_actions(action.name) == action
+        assert actions.get_action(action.name) is action
         assert action in all_actions.values()
 
-    assert actions.query_actions("nonexistent action") is None
+    assert actions.get_action("nonexistent action") is None
 
     all_actions["garbage"] = "mean lean fighting machine"  # type: ignore
     assert (
-        actions.query_actions("garbage") is None
+        actions.get_action("garbage") is None
     ), "`all_actions` should be a copy, changes to it should not effect `_actions`"

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,24 @@
+from porcupine import actions
+
+
+def test_action_registry():
+    bare_action = actions.register_bare_action(
+        name="bare action", description="", callback=lambda: None
+    )
+    filetab_action = actions.register_filetab_action(
+        name="filetab action", description="", callback=lambda tab: None
+    )
+    path_action = actions.register_path_action(
+        name="path action", description="", callback=lambda path: None
+    )
+
+    assert isinstance(bare_action, actions.BareAction)
+    assert isinstance(filetab_action, actions.FileTabAction)
+    assert isinstance(path_action, actions.PathAction)
+
+    all_actions = actions.get_all_actions()
+    for action in [bare_action, filetab_action, path_action]:
+        assert actions.query_actions(action.name) == action
+        assert action in all_actions.values()
+
+    assert actions.query_actions("nonexistent action") is None


### PR DESCRIPTION
First pass, here is how you would register an action that is only available for Markdown files against Paths:
```python
register_path_action(
    name="foo",
    description="bar",
    callback=lambda: None,
    availability_callbacks=[filetype_availability(["Markdown"])],
)
```

I was going to have some dedicated arguments for things like filetype availability, whether or not you can use a directory or a file path, etc, but ultimately I think what makes the most sense is having a single callback that takes a list of `availability_callbacks`, idea being these callbacks will be executed in order, and if any return `False`, the action is not available. I think that creating helpers for this will be extremely flexible, composable, and dev friendly.

Thoughts on how it is so far?

Fixes #1341