### PR TITLE
Get rid of filedialog_kwargs

### DIFF
--- a/docs/porcupine.rst
+++ b/docs/porcupine.rst
@@ -39,20 +39,6 @@ Version Information
           # display an error message or do things without the new feature
 
 
-File Dialogs
-------------
-
-.. data:: filedialog_kwargs
-    :type: dict[str, Any]
-
-    Porcupine uses :mod:`tkinter.filedialog` functions similarly to this::
-
-        path = filedialog.asksaveasfilename(**porcupine.filedialog_kwargs)
-
-    The :source:`filetypes plugin <porcupine/plugins/filetypes.py>` uses this
-    for displaying known filetypes in the dialogs.
-
-
 Directories
 -----------
 

--- a/porcupine/__init__.py
+++ b/porcupine/__init__.py
@@ -41,6 +41,5 @@ get_parsed_args = _state.get_parsed_args
 get_horizontal_panedwindow = _state.get_horizontal_panedwindow  # TODO: document this
 get_vertical_panedwindow = _state.get_vertical_panedwindow  # TODO: document this
 get_tab_manager = _state.get_tab_manager
-filedialog_kwargs = _state.filedialog_kwargs
 add_quit_callback = _state.add_quit_callback
 quit = _state.quit

--- a/porcupine/_state.py
+++ b/porcupine/_state.py
@@ -36,7 +36,6 @@ class _State:
 
 # global state makes some things a lot easier (I'm sorry)
 _global_state: _State | None = None
-filedialog_kwargs: dict[str, Any] = {}
 
 
 def _log_tkinter_error(

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -17,7 +17,7 @@ else:
     from typing_extensions import Literal
 
 from porcupine import pluginmanager, settings, tabs, utils
-from porcupine._state import filedialog_kwargs, get_main_window, get_tab_manager, quit
+from porcupine._state import get_main_window, get_tab_manager, quit
 from porcupine.settings import global_settings
 
 log = logging.getLogger(__name__)
@@ -341,7 +341,7 @@ def _fill_menus_with_default_stuff() -> None:
 
     def open_files() -> None:
         # paths is "" or tuple
-        paths = filedialog.askopenfilenames(**filedialog_kwargs)
+        paths = filedialog.askopenfilenames()
         for path in map(Path, paths):
             get_tab_manager().open_file(path)
 

--- a/porcupine/plugins/filetypes.py
+++ b/porcupine/plugins/filetypes.py
@@ -5,7 +5,6 @@ import argparse
 import fnmatch
 import logging
 import re
-import sys
 import tkinter
 from functools import partial
 from pathlib import Path
@@ -15,14 +14,7 @@ import tomli
 from pygments import lexers
 from pygments.util import ClassNotFound
 
-from porcupine import (
-    dirs,
-    get_parsed_args,
-    get_tab_manager,
-    menubar,
-    settings,
-    tabs,
-)
+from porcupine import dirs, get_parsed_args, get_tab_manager, menubar, settings, tabs
 from porcupine.settings import global_settings
 
 log = logging.getLogger(__name__)

--- a/porcupine/plugins/filetypes.py
+++ b/porcupine/plugins/filetypes.py
@@ -17,7 +17,6 @@ from pygments.util import ClassNotFound
 
 from porcupine import (
     dirs,
-    filedialog_kwargs,
     get_parsed_args,
     get_tab_manager,
     menubar,
@@ -99,27 +98,6 @@ def load_filetypes() -> None:
         # Applies to most other filetypes too e.g. Python file .py and Python stub file .pyi
         assert "filetype_name" not in filetype
         filetype["filetype_name"] = name
-
-
-def set_filedialog_kwargs() -> None:
-    filedialog_kwargs["filetypes"] = []
-
-    for name, filetype in filetypes.items():
-        # "*.py" doesn't work on windows, but ".py" works and does the same thing
-        # See "SPECIFYING EXTENSIONS" in tk_getOpenFile manual page
-        file_patterns = [
-            pattern.split("/")[-1].lstrip("*") for pattern in filetype["filename_patterns"]
-        ]
-
-        filedialog_kwargs["filetypes"].append((name, file_patterns))
-
-    # File types without an extension seem to cause crashes on Mac in certain cases (See issue #1092).
-    if sys.platform != "darwin":
-        filedialog_kwargs["filetypes"].insert(0, ("All Files", ["*"]))
-    else:
-        filedialog_kwargs["filetypes"].remove(
-            ("Makefile", ["Makefile", "makefile", "Makefile.*", "makefile.*"])
-        )
 
 
 def get_filetype_from_matches(
@@ -290,7 +268,6 @@ def setup() -> None:
         "Default filetype for new files:",
         values=sorted(filetypes.keys(), key=str.casefold),
     )
-    set_filedialog_kwargs()
     global filetypes_var
     filetypes_var = tkinter.StringVar()
     for name in sorted(filetypes.keys(), key=str.casefold):

--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -960,7 +960,7 @@ class FileTab(Tab):
         asking the user.
         """
         if path is None:
-            path_string = filedialog.asksaveasfilename(**_state.filedialog_kwargs)
+            path_string = filedialog.asksaveasfilename()
             if not path_string:  # it may be '' because tkinter
                 return False
             path = Path(path_string)

--- a/porcupine/tabs.py
+++ b/porcupine/tabs.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Iterable, NamedTuple, Optional, Sequence, Type
 from pygments.lexer import LexerMeta
 from pygments.lexers import TextLexer
 
-from porcupine import _state, settings, textutils, utils
+from porcupine import settings, textutils, utils
 from porcupine.settings import global_settings
 
 log = logging.getLogger(__name__)

--- a/tests/test_filetypes_plugin.py
+++ b/tests/test_filetypes_plugin.py
@@ -3,11 +3,10 @@ import pickle
 import shutil
 import sys
 from pathlib import Path
-from tkinter import filedialog
 
 import pytest
 
-from porcupine import dirs, filedialog_kwargs, get_main_window
+from porcupine import dirs
 from porcupine.plugins import filetypes
 
 
@@ -33,30 +32,11 @@ settings = {clangd = {arguments = ["-std=c++17"]}}
     )
     filetypes.filetypes.clear()
     filetypes.load_filetypes()
-    filetypes.set_filedialog_kwargs()
 
     yield
     (dirs.user_config_path / "filetypes.toml").unlink()
     filetypes.filetypes.clear()
     filetypes.load_filetypes()
-    filetypes.set_filedialog_kwargs()
-
-
-def test_filedialog_patterns_got_stripped():
-    python_patterns = dict(filedialog_kwargs["filetypes"])["Python"]
-    assert "*.py" not in python_patterns
-    assert ".py" in python_patterns
-
-
-@pytest.mark.skipif(sys.platform != "linux", reason="don't know how filedialog works on non-Linux")
-def test_actually_running_filedialog(custom_filetypes):
-    # Wait and then press Esc. That's done as Tcl code because the Tk widget
-    # representing the dialog can't be used with tkinter.
-    root = get_main_window().nametowidget(".")
-    root.after(1000, root.eval, "event generate [focus] <Escape>")
-
-    # If filedialog_kwargs are wrong, then this errors.
-    filedialog.askopenfilename(**filedialog_kwargs)
 
 
 def test_bad_filetype_on_command_line(run_porcupine):
@@ -97,11 +77,6 @@ def test_slash_in_filename_patterns(custom_filetypes, caplog, tmp_path):
     assert "2 file types match" in caplog.records[0].message
     assert str(tmp_path) in caplog.records[0].message
     assert "HTML, Mako template" in caplog.records[0].message
-
-    # filedialog doesn't support slashes in patterns
-    for filetype_name, patterns in filedialog_kwargs["filetypes"]:
-        for pattern in patterns:
-            assert "/" not in pattern
 
 
 @pytest.mark.skipif(shutil.which("clangd") is None, reason="example config uses clangd")


### PR DESCRIPTION
It will no longer be possible to view e.g. only Python files in the "Open" dialog. I think this is a good thing:
- It is somewhat rare to have lots of files with mixed filetypes in the same directory, the only situation where filtering is actually useful.
- I never used the filtering, and I don't think anyone else used it either.
- Some filetypes caused problems, e.g. Makefiles are recognized by the *prefix* of the name (`Makefile` and `Makefile.foo` are typical names for them) and tkinter doesn't support this on all platforms.
- There were crashes on mac (#1092 and #1333). These are difficult to get right and difficult to test.