### PR TITLE
Fix cyclic anchors bug

### DIFF
--- a/porcupine/plugins/anchors.py
+++ b/porcupine/plugins/anchors.py
@@ -80,7 +80,7 @@ class AnchorManager:
             next_anchor_row = min(rows_after_cursor)
             self.tab_textwidget.mark_set("insert", f"{next_anchor_row}.0")
             self.tab_textwidget.see("insert")
-        elif len(anchor_rows) >= 2 and global_settings.get("anchors_cycle", bool):
+        elif anchor_rows and global_settings.get("anchors_cycle", bool):
             next_anchor_row = min(anchor_rows)
             self.tab_textwidget.mark_set("insert", f"{next_anchor_row}.0")
             self.tab_textwidget.see("insert")
@@ -96,7 +96,7 @@ class AnchorManager:
             previous_anchor_row = max(rows_before_cursor)
             self.tab_textwidget.mark_set("insert", f"{previous_anchor_row}.0")
             self.tab_textwidget.see("insert")
-        elif len(anchor_rows) >= 2 and global_settings.get("anchors_cycle", bool):
+        elif anchor_rows and global_settings.get("anchors_cycle", bool):
             previous_anchor_row = max(anchor_rows)
             self.tab_textwidget.mark_set("insert", f"{previous_anchor_row}.0")
             self.tab_textwidget.see("insert")

--- a/tests/test_anchors_plugin.py
+++ b/tests/test_anchors_plugin.py
@@ -7,9 +7,9 @@ from porcupine.settings import global_settings
 
 
 def move_cursor(filetab, location):
+    filetab.textwidget.mark_set("insert", location)
     if sys.platform == "win32":
         filetab.update()  # no idea why windows need this
-    filetab.textwidget.mark_set("insert", location)
 
 
 def jump_5_times(filetab, how):

--- a/tests/test_anchors_plugin.py
+++ b/tests/test_anchors_plugin.py
@@ -1,4 +1,6 @@
-import pytest,sys
+import sys
+
+import pytest
 
 from porcupine.menubar import get_menu
 from porcupine.settings import global_settings

--- a/tests/test_anchors_plugin.py
+++ b/tests/test_anchors_plugin.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from porcupine.menubar import get_menu
@@ -10,6 +12,12 @@ def jump_5_times(filetab, how):
         get_menu("Edit/Anchors").invoke(how)
         locations.append(filetab.textwidget.index("insert"))
     return locations
+
+
+# TODO: set up windows in a VM and test this locally
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="cursor positions sometimes come out wrong on Windows"
+)
 
 
 def test_basic(filetab):

--- a/tests/test_anchors_plugin.py
+++ b/tests/test_anchors_plugin.py
@@ -1,6 +1,4 @@
-import sys
-
-import pytest
+import pytest,sys
 
 from porcupine.menubar import get_menu
 from porcupine.settings import global_settings

--- a/tests/test_anchors_plugin.py
+++ b/tests/test_anchors_plugin.py
@@ -1,6 +1,5 @@
-import random
 import pytest
-from porcupine import get_main_window
+
 from porcupine.menubar import get_menu
 from porcupine.settings import global_settings
 
@@ -27,7 +26,7 @@ def test_basic(filetab):
     assert jump_5_times(filetab, "Jump to next") == ["2.0", "5.0", "5.0", "5.0", "5.0"]
 
     # Jump backwards
-#    import pdb; pdb.set_trace()
+    #    import pdb; pdb.set_trace()
     filetab.textwidget.mark_set("insert", "end")
     assert jump_5_times(filetab, "Jump to previous") == ["5.0", "2.0", "2.0", "2.0", "2.0"]
 

--- a/tests/test_anchors_plugin.py
+++ b/tests/test_anchors_plugin.py
@@ -26,7 +26,6 @@ def test_basic(filetab):
     assert jump_5_times(filetab, "Jump to next") == ["2.0", "5.0", "5.0", "5.0", "5.0"]
 
     # Jump backwards
-    #    import pdb; pdb.set_trace()
     filetab.textwidget.mark_set("insert", "end")
     assert jump_5_times(filetab, "Jump to previous") == ["5.0", "2.0", "2.0", "2.0", "2.0"]
 

--- a/tests/test_anchors_plugin.py
+++ b/tests/test_anchors_plugin.py
@@ -1,0 +1,56 @@
+import random
+import pytest
+from porcupine import get_main_window
+from porcupine.menubar import get_menu
+from porcupine.settings import global_settings
+
+
+def jump_5_times(filetab, how):
+    locations = []
+    for i in range(5):
+        get_menu("Edit/Anchors").invoke(how)
+        locations.append(filetab.textwidget.index("insert"))
+    return locations
+
+
+def test_basic(filetab):
+    filetab.textwidget.insert("end", "blah\n" * 10)
+
+    # Set anchors on lines 2 and 5. Column numbers should get ignored.
+    filetab.textwidget.mark_set("insert", "2.2")
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
+    filetab.textwidget.mark_set("insert", "5.3")
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
+
+    # Jump forwards, starting at the beginning of the file. Gets stuck at last anchor
+    filetab.textwidget.mark_set("insert", "1.0")
+    assert jump_5_times(filetab, "Jump to next") == ["2.0", "5.0", "5.0", "5.0", "5.0"]
+
+    # Jump backwards
+#    import pdb; pdb.set_trace()
+    filetab.textwidget.mark_set("insert", "end")
+    assert jump_5_times(filetab, "Jump to previous") == ["5.0", "2.0", "2.0", "2.0", "2.0"]
+
+
+@pytest.fixture
+def cyclic_setting_enabled():
+    global_settings.set("anchors_cycle", True)
+    yield
+    global_settings.reset("anchors_cycle")
+
+
+def test_cyclic_jumping(filetab, cyclic_setting_enabled):
+    filetab.textwidget.insert("end", "blah\n" * 10)
+
+    # Set anchors on lines 2, 4 and 7
+    filetab.textwidget.mark_set("insert", "2.0")
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
+    filetab.textwidget.mark_set("insert", "4.0")
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
+    filetab.textwidget.mark_set("insert", "7.0")
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
+
+    # Jump forwards and backwards. It cycles around now.
+    filetab.textwidget.mark_set("insert", "1.0")
+    assert jump_5_times(filetab, "Jump to next") == ["2.0", "4.0", "7.0", "2.0", "4.0"]
+    assert jump_5_times(filetab, "Jump to previous") == ["2.0", "7.0", "4.0", "2.0", "7.0"]

--- a/tests/test_anchors_plugin.py
+++ b/tests/test_anchors_plugin.py
@@ -1,7 +1,13 @@
-import pytest
+import pytest,sys
 
 from porcupine.menubar import get_menu
 from porcupine.settings import global_settings
+
+
+def move_cursor(filetab, location):
+    if sys.platform == "win32":
+        filetab.update()  # no idea why windows need this
+    filetab.textwidget.mark_set("insert", location)
 
 
 def jump_5_times(filetab, how):
@@ -16,17 +22,17 @@ def test_basic(filetab):
     filetab.textwidget.insert("end", "blah\n" * 10)
 
     # Set anchors on lines 2 and 5. Column numbers should get ignored.
-    filetab.textwidget.mark_set("insert", "2.2")
+    move_cursor(filetab, "2.2")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
-    filetab.textwidget.mark_set("insert", "5.3")
+    move_cursor(filetab, "5.3")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
 
     # Jump forwards, starting at the beginning of the file. Gets stuck at last anchor
-    filetab.textwidget.mark_set("insert", "1.0")
+    move_cursor(filetab, "1.0")
     assert jump_5_times(filetab, "Jump to next") == ["2.0", "5.0", "5.0", "5.0", "5.0"]
 
     # Jump backwards
-    filetab.textwidget.mark_set("insert", "end")
+    move_cursor(filetab, "end")
     assert jump_5_times(filetab, "Jump to previous") == ["5.0", "2.0", "2.0", "2.0", "2.0"]
 
 
@@ -41,15 +47,15 @@ def test_cyclic_jumping(filetab, cyclic_setting_enabled):
     filetab.textwidget.insert("end", "blah\n" * 10)
 
     # Set anchors on lines 2, 4 and 7
-    filetab.textwidget.mark_set("insert", "2.0")
+    move_cursor(filetab, "2.0")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
-    filetab.textwidget.mark_set("insert", "4.0")
+    move_cursor(filetab, "4.0")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
-    filetab.textwidget.mark_set("insert", "7.0")
+    move_cursor(filetab, "7.0")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
 
     # Jump forwards and backwards. It cycles around now.
-    filetab.textwidget.mark_set("insert", "1.0")
+    move_cursor(filetab, "1.0")
     assert jump_5_times(filetab, "Jump to next") == ["2.0", "4.0", "7.0", "2.0", "4.0"]
     assert jump_5_times(filetab, "Jump to previous") == ["2.0", "7.0", "4.0", "2.0", "7.0"]
 
@@ -59,13 +65,13 @@ def test_single_anchor_bug(filetab, cyclic_setting_enabled):
     filetab.textwidget.insert("end", "first row\nsecond row")
 
     # Set an anchor point on row 1 & one anchor point on row 2.
-    filetab.textwidget.mark_set("insert", "1.0")
+    move_cursor(filetab, "1.0")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
-    filetab.textwidget.mark_set("insert", "2.0")
+    move_cursor(filetab, "2.0")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
 
     # Set cursor on row 1. Remove the anchor point on row 1.
-    filetab.textwidget.mark_set("insert", "1.0")
+    move_cursor(filetab, "1.0")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
 
     # Use keyboard shortcut to jump to next anchor (down).
@@ -73,7 +79,7 @@ def test_single_anchor_bug(filetab, cyclic_setting_enabled):
     assert filetab.textwidget.index("insert") == "2.0"
 
     # Recreate anchor point on row 1. Make sure cursor is on row 1, then remove anchor point on row 1.
-    filetab.textwidget.mark_set("insert", "1.0")
+    move_cursor(filetab, "1.0")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
 

--- a/tests/test_anchors_plugin.py
+++ b/tests/test_anchors_plugin.py
@@ -1,13 +1,7 @@
-import pytest,sys
+import pytest
 
 from porcupine.menubar import get_menu
 from porcupine.settings import global_settings
-
-
-def move_cursor(filetab, location):
-    if sys.platform == "win32":
-        filetab.update()  # no idea why windows need this
-    filetab.textwidget.mark_set("insert", location)
 
 
 def jump_5_times(filetab, how):
@@ -22,17 +16,17 @@ def test_basic(filetab):
     filetab.textwidget.insert("end", "blah\n" * 10)
 
     # Set anchors on lines 2 and 5. Column numbers should get ignored.
-    move_cursor(filetab, "2.2")
+    filetab.textwidget.mark_set("insert", "2.2")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
-    move_cursor(filetab, "5.3")
+    filetab.textwidget.mark_set("insert", "5.3")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
 
     # Jump forwards, starting at the beginning of the file. Gets stuck at last anchor
-    move_cursor(filetab, "1.0")
+    filetab.textwidget.mark_set("insert", "1.0")
     assert jump_5_times(filetab, "Jump to next") == ["2.0", "5.0", "5.0", "5.0", "5.0"]
 
     # Jump backwards
-    move_cursor(filetab, "end")
+    filetab.textwidget.mark_set("insert", "end")
     assert jump_5_times(filetab, "Jump to previous") == ["5.0", "2.0", "2.0", "2.0", "2.0"]
 
 
@@ -47,15 +41,15 @@ def test_cyclic_jumping(filetab, cyclic_setting_enabled):
     filetab.textwidget.insert("end", "blah\n" * 10)
 
     # Set anchors on lines 2, 4 and 7
-    move_cursor(filetab, "2.0")
+    filetab.textwidget.mark_set("insert", "2.0")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
-    move_cursor(filetab, "4.0")
+    filetab.textwidget.mark_set("insert", "4.0")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
-    move_cursor(filetab, "7.0")
+    filetab.textwidget.mark_set("insert", "7.0")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
 
     # Jump forwards and backwards. It cycles around now.
-    move_cursor(filetab, "1.0")
+    filetab.textwidget.mark_set("insert", "1.0")
     assert jump_5_times(filetab, "Jump to next") == ["2.0", "4.0", "7.0", "2.0", "4.0"]
     assert jump_5_times(filetab, "Jump to previous") == ["2.0", "7.0", "4.0", "2.0", "7.0"]
 
@@ -65,13 +59,13 @@ def test_single_anchor_bug(filetab, cyclic_setting_enabled):
     filetab.textwidget.insert("end", "first row\nsecond row")
 
     # Set an anchor point on row 1 & one anchor point on row 2.
-    move_cursor(filetab, "1.0")
+    filetab.textwidget.mark_set("insert", "1.0")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
-    move_cursor(filetab, "2.0")
+    filetab.textwidget.mark_set("insert", "2.0")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
 
     # Set cursor on row 1. Remove the anchor point on row 1.
-    move_cursor(filetab, "1.0")
+    filetab.textwidget.mark_set("insert", "1.0")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
 
     # Use keyboard shortcut to jump to next anchor (down).
@@ -79,7 +73,7 @@ def test_single_anchor_bug(filetab, cyclic_setting_enabled):
     assert filetab.textwidget.index("insert") == "2.0"
 
     # Recreate anchor point on row 1. Make sure cursor is on row 1, then remove anchor point on row 1.
-    move_cursor(filetab, "1.0")
+    filetab.textwidget.mark_set("insert", "1.0")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
 

--- a/tests/test_anchors_plugin.py
+++ b/tests/test_anchors_plugin.py
@@ -62,29 +62,16 @@ def test_cyclic_jumping(filetab, cyclic_setting_enabled):
     assert jump_5_times(filetab, "Jump to previous") == ["2.0", "7.0", "4.0", "2.0", "7.0"]
 
 
+# See #1353
 def test_single_anchor_bug(filetab, cyclic_setting_enabled):
-    # Setup is exactly as in #1353
     filetab.textwidget.insert("end", "first row\nsecond row")
 
-    # Set an anchor point on row 1 & one anchor point on row 2.
-    filetab.textwidget.mark_set("insert", "1.0")
-    get_menu("Edit/Anchors").invoke("Add or remove on this line")
+    # Line 1 does not have anchor, line 2 has it.
     filetab.textwidget.mark_set("insert", "2.0")
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
 
-    # Set cursor on row 1. Remove the anchor point on row 1.
+    # Because cycling is enabled, jumping to previous anchor from line 1
+    # will jumps to the anchor below.
     filetab.textwidget.mark_set("insert", "1.0")
-    get_menu("Edit/Anchors").invoke("Add or remove on this line")
-
-    # Use keyboard shortcut to jump to next anchor (down).
-    get_menu("Edit/Anchors").invoke("Jump to next")
-    assert filetab.textwidget.index("insert") == "2.0"
-
-    # Recreate anchor point on row 1. Make sure cursor is on row 1, then remove anchor point on row 1.
-    filetab.textwidget.mark_set("insert", "1.0")
-    get_menu("Edit/Anchors").invoke("Add or remove on this line")
-    get_menu("Edit/Anchors").invoke("Add or remove on this line")
-
-    # Use keyboard shortcut to jump to previous anchor (up).
     get_menu("Edit/Anchors").invoke("Jump to previous")
     assert filetab.textwidget.index("insert") == "2.0"

--- a/tests/test_anchors_plugin.py
+++ b/tests/test_anchors_plugin.py
@@ -54,3 +54,31 @@ def test_cyclic_jumping(filetab, cyclic_setting_enabled):
     filetab.textwidget.mark_set("insert", "1.0")
     assert jump_5_times(filetab, "Jump to next") == ["2.0", "4.0", "7.0", "2.0", "4.0"]
     assert jump_5_times(filetab, "Jump to previous") == ["2.0", "7.0", "4.0", "2.0", "7.0"]
+
+
+def test_single_anchor_bug(filetab, cyclic_setting_enabled):
+    # Setup is exactly as in #1353
+    filetab.textwidget.insert("end", "first row\nsecond row")
+
+    # Set an anchor point on row 1 & one anchor point on row 2.
+    filetab.textwidget.mark_set("insert", "1.0")
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
+    filetab.textwidget.mark_set("insert", "2.0")
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
+
+    # Set cursor on row 1. Remove the anchor point on row 1.
+    filetab.textwidget.mark_set("insert", "1.0")
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
+
+    # Use keyboard shortcut to jump to next anchor (down).
+    get_menu("Edit/Anchors").invoke("Jump to next")
+    assert filetab.textwidget.index("insert") == "2.0"
+
+    # Recreate anchor point on row 1. Make sure cursor is on row 1, then remove anchor point on row 1.
+    filetab.textwidget.mark_set("insert", "1.0")
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
+
+    # Use keyboard shortcut to jump to previous anchor (up).
+    get_menu("Edit/Anchors").invoke("Jump to previous")
+    assert filetab.textwidget.index("insert") == "2.0"

--- a/tests/test_anchors_plugin.py
+++ b/tests/test_anchors_plugin.py
@@ -7,9 +7,9 @@ from porcupine.settings import global_settings
 
 
 def move_cursor(filetab, location):
-    filetab.textwidget.mark_set("insert", location)
     if sys.platform == "win32":
         filetab.update()  # no idea why windows need this
+    filetab.textwidget.mark_set("insert", location)
 
 
 def jump_5_times(filetab, how):

--- a/tests/test_anchors_plugin.py
+++ b/tests/test_anchors_plugin.py
@@ -71,7 +71,7 @@ def test_single_anchor_bug(filetab, cyclic_setting_enabled):
     get_menu("Edit/Anchors").invoke("Add or remove on this line")
 
     # Because cycling is enabled, jumping to previous anchor from line 1
-    # will jumps to the anchor below.
+    # will jump to the anchor below.
     filetab.textwidget.mark_set("insert", "1.0")
     get_menu("Edit/Anchors").invoke("Jump to previous")
     assert filetab.textwidget.index("insert") == "2.0"

--- a/tests/test_anchors_plugin.py
+++ b/tests/test_anchors_plugin.py
@@ -3,7 +3,6 @@ import sys
 import pytest
 
 from porcupine.menubar import get_menu
-from porcupine.plugins.anchors import managers  # TODO: invoke the actions when they are a thing
 from porcupine.settings import global_settings
 
 
@@ -13,17 +12,11 @@ def move_cursor(filetab, location):
         filetab.update()  # no idea why windows need this
 
 
-def jump_5_times(filetab, which_way):
+def jump_5_times(filetab, how):
     locations = []
     for i in range(5):
-        if which_way == "up":
-            managers[filetab].jump_to_previous()
-        elif which_way == "down":
-            managers[filetab].jump_to_next()
-        else:
-            raise ValueError(which_way)
+        get_menu("Edit/Anchors").invoke(how)
         locations.append(filetab.textwidget.index("insert"))
-
     return locations
 
 
@@ -32,17 +25,17 @@ def test_basic(filetab):
 
     # Set anchors on lines 2 and 5. Column numbers should get ignored.
     move_cursor(filetab, "2.2")
-    managers[filetab].toggle()
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
     move_cursor(filetab, "5.3")
-    managers[filetab].toggle()
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
 
     # Jump forwards, starting at the beginning of the file. Gets stuck at last anchor
     move_cursor(filetab, "1.0")
-    assert jump_5_times(filetab, "down") == ["2.0", "5.0", "5.0", "5.0", "5.0"]
+    assert jump_5_times(filetab, "Jump to next") == ["2.0", "5.0", "5.0", "5.0", "5.0"]
 
     # Jump backwards
     move_cursor(filetab, "end")
-    assert jump_5_times(filetab, "up") == ["5.0", "2.0", "2.0", "2.0", "2.0"]
+    assert jump_5_times(filetab, "Jump to previous") == ["5.0", "2.0", "2.0", "2.0", "2.0"]
 
 
 @pytest.fixture
@@ -57,16 +50,16 @@ def test_cyclic_jumping(filetab, cyclic_setting_enabled):
 
     # Set anchors on lines 2, 4 and 7
     move_cursor(filetab, "2.0")
-    managers[filetab].toggle()
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
     move_cursor(filetab, "4.0")
-    managers[filetab].toggle()
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
     move_cursor(filetab, "7.0")
-    managers[filetab].toggle()
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
 
     # Jump forwards and backwards. It cycles around now.
     move_cursor(filetab, "1.0")
-    assert jump_5_times(filetab, "down") == ["2.0", "4.0", "7.0", "2.0", "4.0"]
-    assert jump_5_times(filetab, "up") == ["2.0", "7.0", "4.0", "2.0", "7.0"]
+    assert jump_5_times(filetab, "Jump to next") == ["2.0", "4.0", "7.0", "2.0", "4.0"]
+    assert jump_5_times(filetab, "Jump to previous") == ["2.0", "7.0", "4.0", "2.0", "7.0"]
 
 
 def test_single_anchor_bug(filetab, cyclic_setting_enabled):
@@ -75,23 +68,23 @@ def test_single_anchor_bug(filetab, cyclic_setting_enabled):
 
     # Set an anchor point on row 1 & one anchor point on row 2.
     move_cursor(filetab, "1.0")
-    managers[filetab].toggle()
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
     move_cursor(filetab, "2.0")
-    managers[filetab].toggle()
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
 
     # Set cursor on row 1. Remove the anchor point on row 1.
     move_cursor(filetab, "1.0")
-    managers[filetab].toggle()
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
 
     # Use keyboard shortcut to jump to next anchor (down).
-    managers[filetab].jump_to_next()
+    get_menu("Edit/Anchors").invoke("Jump to next")
     assert filetab.textwidget.index("insert") == "2.0"
 
     # Recreate anchor point on row 1. Make sure cursor is on row 1, then remove anchor point on row 1.
     move_cursor(filetab, "1.0")
-    managers[filetab].toggle()
-    managers[filetab].toggle()
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
+    get_menu("Edit/Anchors").invoke("Add or remove on this line")
 
     # Use keyboard shortcut to jump to previous anchor (up).
-    managers[filetab].jump_to_previous()
+    get_menu("Edit/Anchors").invoke("Jump to previous")
     assert filetab.textwidget.index("insert") == "2.0"


### PR DESCRIPTION
Fixes #1353

The problem was that the plugin needed two anchors to be present for cycling back to the start, so it refused to do anything when there was only one. I changed it so that one anchor is enough. We obviously can't do anything if there are no anchors at all.

I also added tests.