### PR TITLE
Auto-generate requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,3 +21,4 @@ types-psutil==5.9.5.10
 types-PyYAML==6.0.12.8
 types-tree-sitter==0.20.1.2
 types-tree-sitter-languages==1.5.0.2
+a

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+# Auto-generated in GitHub Actions. See autofix.yml.
 pytest==6.2.5
 pytest-cov==4.0.0
 pytest-mock==3.10.0
@@ -8,8 +9,6 @@ pyupgrade==3.9.0
 sphinx>=4.0.0, <5.0.0
 pillow>=5.4.1
 requests>=2.24.0, <3.0.0
-
-# type checking, exact versions to avoid "works on my computer" problems
 mypy==1.1.1
 types-Pygments==2.14.0.6
 types-docutils==0.19.1.6
@@ -21,4 +20,3 @@ types-psutil==5.9.5.10
 types-PyYAML==6.0.12.8
 types-tree-sitter==0.20.1.2
 types-tree-sitter-languages==1.5.0.2
-a


### PR DESCRIPTION
Fixes #1410 

This PR only contains the changes to requirements-dev.txt. I am pushing the rest directly to main, because CI doesn't trust pull requests and hence does not run code from the pull request when it has permissions to commit autofixes. This is as intended.