### PR TITLE
Add link checker script for markdown files

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -78,6 +78,7 @@ jobs:
     - run: $PYTHON -m pytest --durations=10
 
   flake8-tkinter:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -88,3 +89,15 @@ jobs:
     # TODO: adding these to requirements-dev.txt breaks pip install
     - run: pip install flake8==5.0.4 flake8-tkinter==0.5.0
     - run: python3 -m flake8 $(git ls-files | grep -E '\.(py|pyw)$')
+
+  markdown-links:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        cache: pip
+    - run: pip install requests
+    - run: python3 scripts/check-markdown-links.py

--- a/dev-doc/architecture-and-design.md
+++ b/dev-doc/architecture-and-design.md
@@ -33,7 +33,7 @@ It will look something like this:
 
 ![Screenshot of porcupine without plugins 1](images/no-plugins-1.png)
 
-![Screenshot of porcupine without plugins 2](images/no-plugins-3.png)
+![Screenshot of porcupine without plugins 2](images/no-plugins-2.png)
 
 
 ## Pros and cons
@@ -115,7 +115,7 @@ If plugin A generates a virtual event on a widget,
 and plugin B binds to that virtual event (in its `setup()`, for example),
 then a callback function specified in plugin B will run whenever plugin A triggers the event.
 This is useful, because plugin A can run code in plugin B without knowing anything about plugin B.
-For more info about virtual events, see [virtual-events.md](virtual-eventsssss.md).
+For more info about virtual events, see [virtual-events.md](virtual-events.md).
 
 
 ## Global State

--- a/dev-doc/architecture-and-design.md
+++ b/dev-doc/architecture-and-design.md
@@ -33,7 +33,7 @@ It will look something like this:
 
 ![Screenshot of porcupine without plugins 1](images/no-plugins-1.png)
 
-![Screenshot of porcupine without plugins 2](images/no-plugins-2.png)
+![Screenshot of porcupine without plugins 2](images/no-plugins-3.png)
 
 
 ## Pros and cons
@@ -115,7 +115,7 @@ If plugin A generates a virtual event on a widget,
 and plugin B binds to that virtual event (in its `setup()`, for example),
 then a callback function specified in plugin B will run whenever plugin A triggers the event.
 This is useful, because plugin A can run code in plugin B without knowing anything about plugin B.
-For more info about virtual events, see [virtual-events.md](virtual-events.md).
+For more info about virtual events, see [virtual-events.md](virtual-eventsssss.md).
 
 
 ## Global State

--- a/dev-doc/virtual-events.md
+++ b/dev-doc/virtual-events.md
@@ -60,7 +60,7 @@ some_widget.bind("<<PrintHi>>", print_hello, add=True)
 some_widget.event_generate("<<PrintHi>>")  # only prints hi
 ```
 
-This is typically used together with [setup_before and setup_after](archotecture-and-design.md#loading-order)
+This is typically used together with [setup_before and setup_after](architecture-and-design.md#loading-order)
 to decide which plugin gets to handle a virtual event.
 
 

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -31,8 +31,8 @@ def find_links(markdown_file_path):
 
     for lineno, line in enumerate(content.splitlines(), start=1):
         link_regexes = [
-            r"\[\S*?\]\((\S*?)\)",  # [text](target)
-            r"^\[.*\]: (\S*)$",  # [text]: target
+            r"\[[^[]]+\]\((\S*?)\)",  # [blah blah](target)
+            r"^\[[^[]]+\]: (\S*)$",  # [blah blah]: target
         ]
         for regex in link_regexes:
             for link_target in re.findall(regex, line):

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -1,5 +1,6 @@
 """Check that links in markdown files point to reasonable places."""
 
+import os
 import re
 import subprocess
 import sys
@@ -9,13 +10,15 @@ from pathlib import Path
 
 import requests
 
+
 PROJECT_ROOT = Path(__file__).absolute().parent.parent
 assert (PROJECT_ROOT / "README.md").is_file()
+os.chdir(PROJECT_ROOT)
 
 
 def find_markdown_files():
-    output = subprocess.check_output(["git", "ls-files", "*.md"], cwd=PROJECT_ROOT, text=True)
-    return [PROJECT_ROOT / line for line in output.splitlines()]
+    output = subprocess.check_output(["git", "ls-files", "*.md"], text=True)
+    return [Path(line) for line in output.splitlines()]
 
 
 def find_links(markdown_file_path):
@@ -66,7 +69,7 @@ def check_link(markdown_file_path, link_target):
 
     path = markdown_file_path.parent / link_target
 
-    if PROJECT_ROOT not in path.parents:
+    if PROJECT_ROOT not in path.resolve().parents:
         return "link points outside of the Porcupine project folder"
 
     if not path.exists():

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -1,13 +1,13 @@
 """Check that links in markdown files point to reasonable places."""
 
-import requests
 import re
-import sys
 import subprocess
+import sys
 from functools import cache
-from pathlib import Path
 from http.client import responses as status_code_names
+from pathlib import Path
 
+import requests
 
 PROJECT_ROOT = Path(__file__).absolute().parent.parent
 assert (PROJECT_ROOT / "README.md").is_file()
@@ -30,7 +30,7 @@ def find_links(markdown_file_path):
     for lineno, line in enumerate(content.splitlines(), start=1):
         link_regexes = [
             r"\[\S*?\]\((\S*?)\)",  # [text](target)
-            r"^\[.*\]: (\S*)$"  # [text]: target
+            r"^\[.*\]: (\S*)$",  # [text]: target
         ]
         for regex in link_regexes:
             for link_target in re.findall(regex, line):

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -86,7 +86,6 @@ def main():
     bad_links = 0
 
     for path in paths:
-        print("Checking", path)
         for lineno, link_target in find_links(path):
             problem = check_link(path, link_target)
             if problem:

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -1,0 +1,104 @@
+"""Check that links in markdown files point to reasonable places."""
+
+import requests
+import re
+import sys
+import subprocess
+from functools import cache
+from pathlib import Path
+from http.client import responses as status_code_names
+
+
+PROJECT_ROOT = Path(__file__).absolute().parent.parent
+assert (PROJECT_ROOT / "README.md").is_file()
+
+
+def find_markdown_files():
+    output = subprocess.check_output(["git", "ls-files", "*.md"], cwd=PROJECT_ROOT, text=True)
+    return [PROJECT_ROOT / line for line in output.splitlines()]
+
+
+def find_links(markdown_file_path):
+    content = markdown_file_path.read_text(encoding="utf-8")
+
+    if markdown_file_path.name == "CHANGELOG.md":
+        # Ignore changelogs of old versions. Editing them doesn't make sense.
+        header_matches = list(re.finditer("^## v", content, flags=re.MULTILINE))
+        end_of_current_version = header_matches[1].start()
+        content = content[:end_of_current_version]
+
+    for lineno, line in enumerate(content.splitlines(), start=1):
+        link_regexes = [
+            r"\[\S*?\]\((\S*?)\)",  # [text](target)
+            r"^\[.*\]: (\S*)$"  # [text]: target
+        ]
+        for regex in link_regexes:
+            for link_target in re.findall(regex, line):
+                yield (lineno, link_target)
+
+
+@cache
+def check_https_url(url):
+    try:
+        # Many sites redirect to front page for bad URLs. Let's not treat that as ok.
+        response = requests.head(url, timeout=1, allow_redirects=False)
+    except requests.exceptions.RequestsException as e:
+        return f"HTTP HEAD request failed: {e}"
+
+    if response.status_code != 200:
+        return f"site returns {response.status_code} {status_code_names[response.status_code]}"
+
+    return None
+
+
+def check_link(markdown_file_path, link_target):
+    if link_target.startswith("http://"):
+        return "this link should probably use https instead of http"
+
+    if link_target.startswith("https://"):
+        return check_https_url(link_target)
+
+    if "//" in link_target:
+        return "double slashes are allowed only in http:// and https:// links"
+
+    if "\\" in link_target:
+        return "use forward slashes instead of backslashes"
+
+    path = markdown_file_path.parent / link_target
+
+    if PROJECT_ROOT not in path.parents:
+        return "link points outside of the Porcupine project folder"
+
+    if not path.exists():
+        return "link points to a file or folder that doesn't exist"
+
+    return None
+
+
+def main():
+    paths = find_markdown_files()
+    assert paths
+
+    good_links = 0
+    bad_links = 0
+
+    for path in paths:
+        print("Checking", path)
+        for lineno, link_target in find_links(path):
+            problem = check_link(path, link_target)
+            if problem:
+                print(f"{path}:{lineno}: {problem}")
+                bad_links += 1
+            else:
+                good_links += 1
+
+    assert good_links + bad_links > 0
+
+    print()
+    print(f"Checked {good_links + bad_links} links in {len(paths)} files.")
+    print(f"Found {bad_links} bad links.")
+    if bad_links > 0:
+        sys.exit(1)
+
+
+main()

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -32,8 +32,8 @@ def find_links(markdown_file_path):
 
     for lineno, line in enumerate(content.splitlines(), start=1):
         link_regexes = [
-            r"\[[^\[\]]+\]\((\S*?)\)",  # [blah blah](target)
-            r"^\[[^\[\]]+\]: (\S*)$",  # [blah blah]: target
+            r"\[[^\[\]]+\]\((\S+?)\)",  # [blah blah](target)
+            r"^\[[^\[\]]+\]: (\S+)$",  # [blah blah]: target
         ]
         for regex in link_regexes:
             for link_target in re.findall(regex, line):

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -64,7 +64,7 @@ def get_all_refs(path):
     result = []
     for title in re.findall(r"\n#+ (.*)", path.read_text()):
         words = re.findall(r"[a-z0-9]+", title.lower())
-        result.append( "#" + "-".join(words))
+        result.append("#" + "-".join(words))
     return result
 
 
@@ -115,8 +115,12 @@ def print_line(file_path, lineno):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--offline", action="store_true", help="don't do HTTP requests, just assume that https:// links are fine")
-    args=parser.parse_args()
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="don't do HTTP requests, just assume that https:// links are fine",
+    )
+    args = parser.parse_args()
 
     paths = find_markdown_files()
     assert paths


### PR DESCRIPTION
I am worried that links in documentation will get outdated over time. This script will check them. The script sends HTTP HEAD requests, but it's probably fine, because the whole purpose of HTTP HEAD is to avoid reading long responses when you don't really care about the contents of a page.

I was going to make this a test, as in `python -m pytest`, but that doesn't work very well for a few reasons:
- Error reporting wouldn't be great. It's hard to show reasonable markdown file line numbers in pytest.
- The test would need to be somehow disabled by default. I don't want to send unsolicited HTTP requests all over the internet from other Porcupine developers' computers. (That said, the pastebin tests already work this way.)

I also tried two existing link checker projects, but they didn't seem to understand that `[...](foo.md)` points at a file named `foo.md` in the same directory.