### PR TITLE
Delete Porcupine Wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,6 @@ Other people shouldn't need them.
     which triggers the parts of `.github/workflows/release-builds.yml`
     that have `if: startsWith(github.ref, 'refs/tags/v')` in them.
     They build and deploy docs, copy the changelog to the releases page, and so on.
-5. Update `porcupine.wiki` if you added new features that are likely not obvious to users.
 
 If you want, you can also do a release from a branch named `bugfix-release` instead of `main`.
 This is useful if you fixed a bug that made Porcupine unusable for someone,

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Most of Porcupine's documentation is markdown files in two folders:
 - [The `dev-doc` folder](./dev-doc/) contains the documentation for developing Porcupine.
 - [The `user-doc` folder](./user-doc/) contains the documentation for using Porcupine.
 
-There are also these two other, deprecated places, where you will find the same documentation:
+There are also these two other, deprecated places:
 - [akuli.github.io/porcupine](https://akuli.github.io/porcupine/) (not updated since June 2023)
 - [The `docs` folder](./docs/) defines the content that was published at `akuli.github.io/porcupine`.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If you have just installed Porcupine, have a look at [user-doc/getting-started.m
 If you want to develop Porcupine, see [CONTRIBUTING.md](CONTRIBUTING.md) or [dev-doc/architecture-and-design.md](dev-doc/architecture-and-design.md).
 
 Most of Porcupine's documentation is markdown files in two folders:
-- [The dev-doc folder](./dev-doc/) contains the documentation for developing Porcupine.
+- [The `dev-doc` folder](./dev-doc/) contains the documentation for developing Porcupine.
 - [The `user-doc` folder](./user-doc/) contains the documentation for using Porcupine.
 
 There are also these two other, deprecated places, where you will find the same documentation:

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ Most of Porcupine's documentation is markdown files in two folders:
 - [user-doc](./user-doc/) contains the documentation for using Porcupine.
 
 There are also these two other, deprecated places, where you will mostly find outdated and useless documentation:
-- [Porcupine Wiki](https://github.com/Akuli/porcupine/wiki) (not updated since May 2022)
 - [Plugin API Documentation](https://akuli.github.io/porcupine/) (not updated since June 2023)
 
 I will hopefully migrate their content to the two new places soon-ish.
@@ -144,9 +143,9 @@ See [issue #1308](https://github.com/Akuli/porcupine/issues/1308) for discussion
 See [CHANGELOG.md](CHANGELOG.md).
 
 ### Does Porcupine support programming language X?
-You will likely get syntax highlighting without any configuring
+You will likely get syntax highlighting without any configuring,
 and autocompletions with a few lines of configuration file editing.
-See [the instructions on Porcupine wiki](https://github.com/Akuli/porcupine/wiki/Getting-Porcupine-to-work-with-a-programming-language).
+See [this documentation](user-doc/new-programming-language.md).
 
 ### Help! Porcupine doesn't work.
 Please install the latest version.

--- a/README.md
+++ b/README.md
@@ -126,13 +126,14 @@ If you have just installed Porcupine, have a look at [user-doc/getting-started.m
 If you want to develop Porcupine, see [CONTRIBUTING.md](CONTRIBUTING.md) or [dev-doc/architecture-and-design.md](dev-doc/architecture-and-design.md).
 
 Most of Porcupine's documentation is markdown files in two folders:
-- [dev-doc](./dev-doc/) contains the documentation for developing Porcupine.
-- [user-doc](./user-doc/) contains the documentation for using Porcupine.
+- [The dev-doc folder](./dev-doc/) contains the documentation for developing Porcupine.
+- [The `user-doc` folder](./user-doc/) contains the documentation for using Porcupine.
 
-There are also these two other, deprecated places, where you will mostly find outdated and useless documentation:
-- [Plugin API Documentation](https://akuli.github.io/porcupine/) (not updated since June 2023)
+There are also these two other, deprecated places, where you will find the same documentation:
+- [akuli.github.io/porcupine](https://akuli.github.io/porcupine/) (not updated since June 2023)
+- [The `docs` folder](./docs/) defines the content that was published at `akuli.github.io/porcupine`.
 
-I will hopefully migrate their content to the two new places soon-ish.
+I will hopefully update and migrate their content to the two new places soon-ish.
 See [issue #1308](https://github.com/Akuli/porcupine/issues/1308) for discussion about the docs situation.
 
 

--- a/porcupine/default_filetypes.toml
+++ b/porcupine/default_filetypes.toml
@@ -1,9 +1,10 @@
 # These settings can be overrided in your user-specific filetypes.toml. To edit
 # it, go to Settings --> Config Files.
 #
-# There's a friendly introduction to editing this file on Porcupine Wiki:
+# For an overview of adding support for a new programming language (filetype),
+# see this documentation:
 #
-#    https://github.com/Akuli/porcupine/wiki/Getting-Porcupine-to-work-with-a-programming-language
+#    https://github.com/Akuli/porcupine/blob/main/user-doc/new-programming-language.md
 #
 # Most commonly used options (plugins may add more):
 #

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -448,24 +448,13 @@ def _fill_menus_with_default_stuff() -> None:
     get_menu("Settings").add_command(label="Porcupine Settings", command=settings.show_dialog)
     get_menu("Settings").add_command(label="Plugin Manager", command=pluginmanager.show_dialog)
 
+    # TODO: these really belong to a plugin
     def add_link(menu_path: str, label: str, url: str) -> None:
         get_menu(menu_path).add_command(label=label, command=(lambda: webbrowser.open(url)))
 
-    # TODO: porcupine starring button
-    add_link("Help", "Porcupine Wiki", "https://github.com/Akuli/porcupine/wiki")
+    add_link("Help", "Create an issue on GitHub", "https://github.com/Akuli/porcupine/issues/new")
     add_link(
         "Help",
-        "Report a problem or request a feature",
-        "https://github.com/Akuli/porcupine/issues/new",
+        "User Documentation",
+        "https://github.com/Akuli/porcupine/tree/main/user-doc"
     )
-    add_link(
-        "Help/Python",
-        "Free help chat",
-        "https://kiwiirc.com/nextclient/irc.libera.chat/##learnpython",
-    )
-    add_link(
-        "Help/Python",
-        "My Python tutorial",
-        "https://github.com/Akuli/python-tutorial/blob/master/README.md",
-    )
-    add_link("Help/Python", "Official documentation", "https://docs.python.org/")

--- a/porcupine/menubar.py
+++ b/porcupine/menubar.py
@@ -453,8 +453,4 @@ def _fill_menus_with_default_stuff() -> None:
         get_menu(menu_path).add_command(label=label, command=(lambda: webbrowser.open(url)))
 
     add_link("Help", "Create an issue on GitHub", "https://github.com/Akuli/porcupine/issues/new")
-    add_link(
-        "Help",
-        "User Documentation",
-        "https://github.com/Akuli/porcupine/tree/main/user-doc"
-    )
+    add_link("Help", "User Documentation", "https://github.com/Akuli/porcupine/tree/main/user-doc")

--- a/porcupine/plugins/aboutdialog.py
+++ b/porcupine/plugins/aboutdialog.py
@@ -135,14 +135,11 @@ Python using the notorious tkinter GUI library. It started as a \
 proof-of-concept of a somewhat good editor written in tkinter, but nowadays \
 it's a tool I use at work every day.
 
-I'm [Akuli](https://github.com/Akuli), and I wrote most of Porcupine. See \
-[the contributor \
-page](https://github.com/Akuli/porcupine/graphs/contributors) for details.
+I'm [Akuli](https://github.com/Akuli), and I wrote most of Porcupine. \
+That said, Porcupine wouldn't be what it is now without the feedback and contributions of many other people. \
+See [the contributor page](https://github.com/Akuli/porcupine/graphs/contributors) for details.
 
-Links:
-\N{bullet} [Porcupine Wiki](https://github.com/Akuli/porcupine/wiki)
-\N{bullet} [Porcupine on GitHub](https://github.com/Akuli/porcupine)
-\N{bullet} [Plugin API documentation for Python programmers](https://akuli.github.io/porcupine/)
+Porcupine is developed in [this GitHub repo](https://github.com/Akuli/porcupine).
 
 Porcupine is available under the MIT license. It means that you can do \
 pretty much anything you want with it as long as you distribute the \

--- a/user-doc/getting-started.md
+++ b/user-doc/getting-started.md
@@ -56,12 +56,16 @@ That said, don't memorize keyboard shortcuts for things you almost never use.
 
 Here are some of the most important things:
 
-### "Report a problem or request a feature" in the Help menu
+### "Create an issue on GitHub" in the Help menu
 
 This button opens a browser window to create an issue on GitHub.
-If you are new to Porcupine, you will probably have some problems getting started with it,
-and you will probably discover some bugs.
-Please tell me about them :)
+Use it to report problems, request features, or to leave any other feedback to Porcupine developers.
+As you use Porcupine, you will probably experience problems and discover bugs.
+Please tell us about them so that we can fix them :)
+
+### "User Documentation" in the Help menu
+
+It opens this documentation.
 
 ### "Porcupine Settings" in the Settings menu
 


### PR DESCRIPTION
All content except the key cheatsheet has been updated and moved to `user-doc`. I'm not sure if I want to keep the key cheatsheet, as it is kinda incomplete anyway. I can always add it back later.

This is an important part of fixing #1308.