### PR TITLE
Show warning if plugin docstring/description is missing

### DIFF
--- a/porcupine/pluginloader.py
+++ b/porcupine/pluginloader.py
@@ -215,6 +215,12 @@ def _run_setup_and_set_status(info: PluginInfo) -> None:
                     f"{record.levelname}: {record.message}\n" for record in error_log
                 )
             else:
+                if not getattr(info.module, "__doc__", None):
+                    log.warning(
+                        f"Please add a docstring to the {info.name!r} plugin. It will show up in"
+                        f" the plugin manager when the {info.name!r} plugin is selected, so that"
+                        " users know what the plugin does."
+                    )
                 info.status = Status.ACTIVE
 
         duration = time.perf_counter() - start

--- a/porcupine/plugins/hover.py
+++ b/porcupine/plugins/hover.py
@@ -1,3 +1,12 @@
+"""
+Show messages when you bring the mouse or the cursor on top of e.g. a function
+name or a URL in the main editing area.
+
+This plugin does nothing by itself, and needs some other plugin (usually
+underlines or langserver) to tell it what the hovering tooltips should say and
+when to display them.
+"""
+
 from __future__ import annotations
 
 import dataclasses

--- a/porcupine/plugins/rightclick_menu.py
+++ b/porcupine/plugins/rightclick_menu.py
@@ -1,3 +1,4 @@
+"""Display a menu when the main editing area is right-clicked."""
 from __future__ import annotations
 
 import tkinter

--- a/porcupine/plugins/update_check.py
+++ b/porcupine/plugins/update_check.py
@@ -1,3 +1,10 @@
+"""Check for updates when Porcupine starts.
+
+If a new version of Porcupine has been released, this plugin notifies you about
+it by showing a message in the status bar. If you don't like it, uncheck the
+"Check for updates when Porcupine starts" checkbox in the settings or disable
+this plugin.
+"""
 from __future__ import annotations
 
 import datetime


### PR DESCRIPTION
Fixes #1484

The warning is shown only after a successful `setup()`, because otherwise you get a somewhat unimportant warning along with a much more important error.