### PR TITLE
Increase HTTP timeout in check-markdown-links.py

### DIFF
--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -48,7 +48,7 @@ def find_links(markdown_file_path):
 def check_https_url(url):
     try:
         # Many sites redirect to front page for bad URLs. Let's not treat that as ok.
-        response = requests.head(url, timeout=1, allow_redirects=False)
+        response = requests.head(url, timeout=10, allow_redirects=False)
     except requests.exceptions.RequestException as e:
         return f"HTTP HEAD request failed: {e}"
 


### PR DESCRIPTION
This will hopefully fix the random CI failures coming from this script.

Ideally the CI check would fail only if a link hasn't worked for the last couple days, so that if one of the linked websites is down for a few hours, it doesn't cause CI failures here. But that would be more effort to set up, and this might work fine.