### PR TITLE
Fix simple terminal run command in external window

### DIFF
--- a/porcupine/plugins/run/terminal.py
+++ b/porcupine/plugins/run/terminal.py
@@ -129,7 +129,10 @@ def _run_in_x11_like_terminal(command: str | None, cwd: Path, env: dict[str, str
 
     if command:
         real_command = [str(run_script), str(cwd), command]
-        subprocess.Popen([terminal, "-e", " ".join(map(shlex.quote, real_command))], env=env)
+        if terminal == "st":
+            subprocess.Popen([terminal, "-e", *real_command], env=env)
+        else:
+            subprocess.Popen([terminal, "-e", " ".join(map(shlex.quote, real_command))], env=env)
     else:
         subprocess.Popen(terminal, cwd=cwd, env=env)
 


### PR DESCRIPTION
This works on my own build with various patches for v0.9.1 and the default for v0.9.2.

Not sure if this is the best implementation, so please tell me how I can improve.

Fixes  #1513