### PR TITLE
Fix trailing newline

### DIFF
--- a/porcupine/plugins/trailing_newline.py
+++ b/porcupine/plugins/trailing_newline.py
@@ -9,7 +9,8 @@ from porcupine import get_tab_manager, tabs
 def on_save(event: tkinter.Event[tabs.FileTab]) -> None:
     if event.widget.settings.get("insert_final_newline", bool):
         textwidget = event.widget.textwidget
-        if textwidget.get("end - 2 chars", "end - 1 char") != "\n":
+        char = textwidget.get("end - 2 chars", "end - 1 char")
+        if char and char != "\n":
             # doesn't end with a \n yet, be sure not to annoyingly move the
             # cursor like IDLE does
             cursor = textwidget.index("insert")

--- a/tests/test_trailing_newline_plugin.py
+++ b/tests/test_trailing_newline_plugin.py
@@ -1,8 +1,10 @@
 def test_trailing_newline(filetab, tmp_path):
     filetab.path = tmp_path / "foo.py"
 
+    assert filetab.textwidget.get("1.0", "end ") == "\n"
     filetab.save()
-    assert (tmp_path / "foo.py").read_text() == "\n"
+    assert filetab.textwidget.get("1.0", "end ") == "\n"
+    assert (tmp_path / "foo.py").read_text() == ""
 
     filetab.textwidget.insert("1.0", "hello")
     assert filetab.textwidget.get("1.0", "end - 1 char") == "hello"

--- a/tests/test_trailing_newline_plugin.py
+++ b/tests/test_trailing_newline_plugin.py
@@ -1,5 +1,9 @@
 def test_trailing_newline(filetab, tmp_path):
     filetab.path = tmp_path / "foo.py"
+
+    filetab.save()
+    assert (tmp_path / "foo.py").read_text() == "\n"
+
     filetab.textwidget.insert("1.0", "hello")
     assert filetab.textwidget.get("1.0", "end - 1 char") == "hello"
 

--- a/tests/test_trailing_newline_plugin.py
+++ b/tests/test_trailing_newline_plugin.py
@@ -1,9 +1,9 @@
 def test_trailing_newline(filetab, tmp_path):
     filetab.path = tmp_path / "foo.py"
 
-    assert filetab.textwidget.get("1.0", "end ") == "\n"
+    assert filetab.textwidget.get("1.0", "end") == "\n"
     filetab.save()
-    assert filetab.textwidget.get("1.0", "end ") == "\n"
+    assert filetab.textwidget.get("1.0", "end") == "\n"
     assert (tmp_path / "foo.py").read_text() == ""
 
     filetab.textwidget.insert("1.0", "hello")


### PR DESCRIPTION
Checks that the file has a character to reference (if there is no second character in the file, it will never equal the newline so we have to account for that)

Fixes #1505